### PR TITLE
chore: release provenance

### DIFF
--- a/.changeset/provenance-republish.md
+++ b/.changeset/provenance-republish.md
@@ -1,0 +1,6 @@
+---
+"@cloudflare/nimbus-docs": patch
+"@cloudflare/create-nimbus-docs": patch
+---
+
+Republish with npm provenance attestations. Supersedes 0.6.0 / 0.5.0, which published without provenance and before the repo was public.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          # TODO(flip): restore NPM_CONFIG_PROVENANCE before the first public release
+          NPM_CONFIG_PROVENANCE: "true"
 
       # Normal path. On a push with pending changesets, opens/updates the
       # "chore: bump package versions" PR (branch `changeset-release/*`). When
@@ -127,4 +127,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          # TODO(flip): restore NPM_CONFIG_PROVENANCE before the first public release
+          NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
## What & why

<!-- What this changes and why. Link the issue or discussion it came from. -->

## Checklist

- [ ] A maintainer approved this work (`lgtm+` on my issue or discussion), or I'm on the team
- [ ] Correct tier (framework / starter / registry) per the boundary test
- [ ] Edited `packages/nimbus-starter-source/`, not the `templates` branch
- [ ] Changeset added (`create-nimbus-docs` changeset if the starter changed)
- [ ] `pnpm typecheck`, `pnpm -r test`, and `pnpm templates:check` all green

<details>
<summary>First time here?</summary>

Nimbus works from issues and discussions, not drive-by PRs, so unapproved PRs from
outside the team are closed automatically. If that's you, open an
[issue](https://github.com/cloudflare/nimbus/issues/new/choose) (bug or fix proposal)
or a [discussion](https://github.com/cloudflare/nimbus/discussions) (feature) instead —
once a maintainer approves you there, your PRs stay open. See
[CONTRIBUTING.md](https://github.com/cloudflare/nimbus/blob/main/CONTRIBUTING.md).

</details>
