### PR TITLE
chore: approved contributors change

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -6,3 +6,5 @@
 # Remove: comment `lgtm- @username`.
 #
 # Org owners, members, and collaborators are already exempt and don't belong here.
+
+matthewp  # direct add ahead of incoming PR, 2026-07-22

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,8 +20,7 @@ Use GitHub's private vulnerability reporting flow for this repository:
 2. Choose **Report a vulnerability**.
 3. Include enough detail for maintainers to reproduce and assess the issue.
 
-For Cloudflare-wide programs you can also report via
-[hackerone.com/cloudflare](https://hackerone.com/cloudflare). If you already
+If you already
 submitted a private advisory, keep follow-up discussion in that thread. Avoid
 opening public issues for exploitable details; a public issue may be used only
 to ask for routing or status without sharing sensitive technical information.


### PR DESCRIPTION
## What & why

<!-- What this changes and why. Link the issue or discussion it came from. -->

## Checklist

- [ ] A maintainer approved this work (`lgtm+` on my issue or discussion), or I'm on the team
- [ ] Correct tier (framework / starter / registry) per the boundary test
- [ ] Edited `packages/nimbus-starter-source/`, not the `templates` branch
- [ ] Changeset added (`create-nimbus-docs` changeset if the starter changed)
- [ ] `pnpm typecheck`, `pnpm -r test`, and `pnpm templates:check` all green

<details>
<summary>First time here?</summary>

Nimbus works from issues and discussions, not drive-by PRs, so unapproved PRs from
outside the team are closed automatically. If that's you, open an
[issue](https://github.com/cloudflare/nimbus/issues/new/choose) (bug or fix proposal)
or a [discussion](https://github.com/cloudflare/nimbus/discussions) (feature) instead —
once a maintainer approves you there, your PRs stay open. See
[CONTRIBUTING.md](https://github.com/cloudflare/nimbus/blob/main/CONTRIBUTING.md).

</details>
