### PR TITLE
Add pkg.pr.new preview releases

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -1,0 +1,102 @@
+name: Preview release
+
+# On-demand preview builds for a PR, served by pkg.pr.new (https://pkg.pr.new).
+# A maintainer adds the `pr preview` label; this builds the two publishable
+# packages and publishes them to pkg.pr.new, which serves them from its own
+# npm-compatible URLs (nothing is published to the npm registry). The pkg-pr-new
+# bot then comments on the PR with install commands like
+# `pnpm add https://pkg.pr.new/@cloudflare/nimbus-docs@<PR#>`.
+#
+# The label is removed at the end, so re-adding it triggers a fresh preview.
+on:
+  pull_request:
+    branches: [main]
+    types: [labeled]
+
+# One preview per PR; a newer label event cancels the older run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+# Default-deny; the job opts into exactly what it needs.
+permissions: {}
+
+jobs:
+  preview:
+    name: Build & publish preview
+    # Only the `pr preview` label, only on this repo, and only for same-repo
+    # branches. Forks don't receive the OIDC id-token that pkg.pr.new
+    # authenticates with (and PR policy already redirects unsolicited forks),
+    # so a fork run could never publish anyway.
+    if: >-
+      github.repository == 'cloudflare/nimbus' &&
+      github.event.label.name == 'pr preview' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write # remove the trigger label; the bot's PR comment uses the App's own token
+      id-token: write # pkg.pr.new authenticates the publish via GitHub OIDC (no npm token, no secret)
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Build only what gets published. The root `build` also builds the private
+      # @nimbus/www site + starter source; a failure there must not block a
+      # preview. (pkg-pr-new also runs each package's `prepack` when packing, so
+      # this is belt-and-suspenders — but it keeps a build break visible as its
+      # own step rather than buried in the publish output.)
+      - run: pnpm --filter ./packages/nimbus-docs --filter ./packages/create-nimbus-docs build
+
+      # Remove the label before publishing so a maintainer can re-add it to
+      # retry, even if the publish step below fails.
+      - name: Remove preview label
+        run: gh pr edit "$PR" --repo "$REPO" --remove-label "pr preview"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.number }}
+
+      # Publish both publishable packages in a single invocation. pkg-pr-new is
+      # deliberately run ONCE for all packages (running it per-package is how it
+      # spams). We publish both unconditionally rather than filtering by pending
+      # changesets (as larger monorepos do) — there are only two publishables,
+      # and a preview is for testing a branch that may not have a changeset yet.
+      #
+      #   --pnpm            pack with `pnpm pack` (matches this repo's toolchain)
+      #   --compact         short URLs (both packages are on npm with a correct
+      #                     `repository` field; falls back to long form if not)
+      #   --no-template     skip the Stackblitz playground (irrelevant for a docs framework)
+      #   --packageManager  show `pnpm add …` in the PR comment, matching Nimbus's default
+      #
+      # Note on create-nimbus-docs: its preview is of limited use on its own —
+      # the scaffolder fetches templates pinned to `#templates-v<version>`, so a
+      # preview build still pulls the last RELEASED templates, not this PR's
+      # starter changes. To test starter edits end to end, scaffold with
+      # `--template-dir` against a local checkout (see `pnpm local`).
+      #
+      # Prerequisites (one-time, outside this file):
+      #   - Install the pkg-pr-new GitHub App (https://github.com/apps/pkg-pr-new)
+      #     on cloudflare/nimbus. The App install + OIDC id-token IS the auth;
+      #     there is no token secret.
+      #   - The repo must be PUBLIC. pkg.pr.new serves artifacts from public,
+      #     unauthenticated URLs and does not support private repos — same
+      #     public-flip prerequisite the npm release already depends on.
+      - name: Publish preview
+        run: >-
+          pnpm exec pkg-pr-new publish
+          --pnpm
+          --compact
+          --no-template
+          --packageManager=pnpm
+          ./packages/nimbus-docs
+          ./packages/create-nimbus-docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,4 +43,23 @@ Before you open a PR:
 - Add a changeset for anything user-facing. Starter edits need a `create-nimbus-docs` changeset, or the freshness guard fails the PR.
 - Check that `pnpm typecheck`, `pnpm -r test`, and `pnpm templates:check` pass.
 
+### Preview releases
+
+To let someone install and test a PR before it merges, add the `pr preview`
+label to it. That triggers the [Preview release](.github/workflows/preview-release.yml)
+workflow, which builds `@cloudflare/nimbus-docs` and `@cloudflare/create-nimbus-docs`
+and publishes them to [pkg.pr.new](https://pkg.pr.new) — nothing hits the npm
+registry. A bot then comments on the PR with install commands like:
+
+```sh
+pnpm add https://pkg.pr.new/@cloudflare/nimbus-docs@<PR#>
+```
+
+The label is removed automatically; re-add it to publish a fresh preview.
+
+Note that `create-nimbus-docs` previews are limited: the scaffolder fetches
+templates pinned to `#templates-v<version>`, so a preview still pulls the last
+*released* templates, not the PR's starter edits. To test starter changes end to
+end, scaffold with `--template-dir` against a local checkout (see `pnpm local`).
+
 `CLAUDE.md` and `AGENT.md` have the full picture.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",
-    "@changesets/cli": "^2.31.0"
+    "@changesets/cli": "^2.31.0",
+    "pkg-pr-new": "^0.0.79"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.31.0
         version: 2.31.0(@types/node@20.19.41)
+      pkg-pr-new:
+        specifier: ^0.0.79
+        version: 0.0.79
 
   apps/www:
     dependencies:
@@ -692,31 +695,31 @@ packages:
         optional: true
 
   '@cloudflare/workerd-darwin-64@1.20260526.1':
-    resolution: {integrity: sha512-/pR3GH3gfv0PUp7DjI8v0aAIDOqFwibq4bg5xT7TZgcVdBV/cJQWckdXCMqiRtHiawLwogUX00EIOINkYJ1Zqg==, tarball: https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260526.1.tgz}
+    resolution: {integrity: sha512-/pR3GH3gfv0PUp7DjI8v0aAIDOqFwibq4bg5xT7TZgcVdBV/cJQWckdXCMqiRtHiawLwogUX00EIOINkYJ1Zqg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
   '@cloudflare/workerd-darwin-arm64@1.20260526.1':
-    resolution: {integrity: sha512-rcyu0iANYfaiezKh3Mcao1O4IIgVfQldxduiL5TZT1sP0NIeRY4YReSTrzPxNnXxSYaIqaqRHMcHbUM/ic4knA==, tarball: https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260526.1.tgz}
+    resolution: {integrity: sha512-rcyu0iANYfaiezKh3Mcao1O4IIgVfQldxduiL5TZT1sP0NIeRY4YReSTrzPxNnXxSYaIqaqRHMcHbUM/ic4knA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
   '@cloudflare/workerd-linux-64@1.20260526.1':
-    resolution: {integrity: sha512-5EZAEnlLwa9oGJRo8Nd3iY5Wcd9ROGNNG90xNIGp8MEjj8v2jTn42NC47fCZKFdnLj3+S+vWEhu1x0GVJnALjA==, tarball: https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260526.1.tgz}
+    resolution: {integrity: sha512-5EZAEnlLwa9oGJRo8Nd3iY5Wcd9ROGNNG90xNIGp8MEjj8v2jTn42NC47fCZKFdnLj3+S+vWEhu1x0GVJnALjA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
   '@cloudflare/workerd-linux-arm64@1.20260526.1':
-    resolution: {integrity: sha512-X/YBQXeXFeCN7QTStoWrATEBc9WKl7PIqkw/dQkjyJ72gh3rkLe0+Xkzp3wO7gtxTDQMa7NPGy1W4+sdMf8q1g==, tarball: https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260526.1.tgz}
+    resolution: {integrity: sha512-X/YBQXeXFeCN7QTStoWrATEBc9WKl7PIqkw/dQkjyJ72gh3rkLe0+Xkzp3wO7gtxTDQMa7NPGy1W4+sdMf8q1g==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
   '@cloudflare/workerd-windows-64@1.20260526.1':
-    resolution: {integrity: sha512-R+tqpFFdcfZIljx8fIW9rj9fRTtDgfoA2yonsfAGa6e8snrmr+38mdFHtkRC0D3UyZpn/hOtmXiUBfdX2gMR7Q==, tarball: https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260526.1.tgz}
+    resolution: {integrity: sha512-R+tqpFFdcfZIljx8fIW9rj9fRTtDgfoA2yonsfAGa6e8snrmr+38mdFHtkRC0D3UyZpn/hOtmXiUBfdX2gMR7Q==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -3438,6 +3441,10 @@ packages:
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
+
+  pkg-pr-new@0.0.79:
+    resolution: {integrity: sha512-ip74NzaakGZha5s/X1T7j+Ez9/bRNDhzxQZTfnzAzoI7zO9JnMRdoiIfCLyy+ZzxxXg8WXRW2WcdvdORI0O30w==}
+    hasBin: true
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -7814,6 +7821,8 @@ snapshots:
   picomatch@4.0.5: {}
 
   pify@4.0.1: {}
+
+  pkg-pr-new@0.0.79: {}
 
   pkg-types@1.3.1:
     dependencies:


### PR DESCRIPTION
## What & why

This adds preview release support. If you add the `pr preview` label to a PR it will trigger this workflow to run and publish a preview to pkg.pr.new.

Before you merge this, a repo admin needs to [install pkg-pr-new GitHub App](https://github.com/apps/pkg-pr-new)

## Checklist

- [x] A maintainer approved this work (`lgtm+` on my issue or discussion), or I'm on the team
- [ ] Correct tier (framework / starter / registry) per the boundary test
- [ ] Edited `packages/nimbus-starter-source/`, not the `templates` branch
- [ ] Changeset added (`create-nimbus-docs` changeset if the starter changed)
- [ ] `pnpm typecheck`, `pnpm -r test`, and `pnpm templates:check` all green
