### PR TITLE
perf: skip hashing temporary prerender chunks

### DIFF
--- a/packages/nimbus-docs/src/integration.ts
+++ b/packages/nimbus-docs/src/integration.ts
@@ -559,6 +559,38 @@ export function nimbus(
           );
         }
 
+        // Astro's prerender bundle is temporary: it is imported to render the
+        // static pages and then deleted. Hashing its thousands of lazy content
+        // chunks can dominate large documentation builds because Rollup walks
+        // the transitive chunk graph once per hash placeholder. Keep asset
+        // hashes (they are copied to the final site), but use deterministic,
+        // hashless names for the temporary JavaScript chunks. Rollup resolves
+        // duplicate `[name]` values with stable numeric suffixes.
+        //
+        // Respect either environment-specific or inherited top-level output
+        // naming supplied by the consumer. Output arrays are uncommon for an
+        // Astro app and cannot be safely overlaid with an object, so leave them
+        // untouched as well.
+        const topLevelOutput = astroConfig.vite?.build?.rollupOptions?.output;
+        const prerenderOutput = astroConfig.vite?.environments?.prerender?.build
+          ?.rollupOptions?.output;
+        const canDefaultPrerenderNames =
+          !Array.isArray(topLevelOutput) && !Array.isArray(prerenderOutput);
+        const topLevelOutputOptions = canDefaultPrerenderNames ? topLevelOutput : undefined;
+        const prerenderOutputOptions = canDefaultPrerenderNames ? prerenderOutput : undefined;
+        const hashlessPrerenderOutput = canDefaultPrerenderNames
+          ? {
+              ...(topLevelOutputOptions?.entryFileNames === undefined &&
+              prerenderOutputOptions?.entryFileNames === undefined
+                ? { entryFileNames: "prerender-entry.mjs" }
+                : {}),
+              ...(topLevelOutputOptions?.chunkFileNames === undefined &&
+              prerenderOutputOptions?.chunkFileNames === undefined
+                ? { chunkFileNames: "chunks/[name].mjs" }
+                : {}),
+            }
+          : null;
+
         updateConfig({
           // Bridge `nimbusConfig.site` → Astro's top-level `site`. The
           // sitemap integration and `Astro.site` both read this; without
@@ -662,6 +694,18 @@ export function nimbus(
           //      the llms.txt routes) and the versioning alternates
           //      table.
           vite: {
+            ...(hashlessPrerenderOutput &&
+            Object.keys(hashlessPrerenderOutput).length > 0
+              ? {
+                  environments: {
+                    prerender: {
+                      build: {
+                        rollupOptions: { output: hashlessPrerenderOutput },
+                      },
+                    },
+                  },
+                }
+              : {}),
             plugins: [
               ...admonitionVitePlugins,
               virtualConfigPlugin(config, {


### PR DESCRIPTION
## Summary

- use deterministic, hashless filenames for JavaScript emitted by Astro's temporary prerender environment
- preserve hashes for assets that are copied into the final site
- preserve consumer-supplied Rollup output naming and leave array-form output configurations untouched

## Why

Astro imports the prerender bundle to generate static pages and deletes it afterward. On large sites, Rollup's final hash generation repeatedly walks the transitive graph for thousands of temporary lazy chunks. This Rollup hashing was built for actually shipped bundles, for cache and cache busting purposes, but instead it is used on an intermediate local only build.

On the current Cloudflare Docs build (8,708 pages), an isolated cold-build A/B measured:

| Variant | Wall time | Prerender Vite bundle |
| --- | ---: | ---: |
| Normal hashed chunks | 7:43.99 | 3m 51s |
| Hashless temporary chunks | 5:23.51 | 1m 39s |

That is 2m 20.48s less wall time (30.3%) and 2m 12s less prerender bundling time (57%). Both builds used identical source and had `dist`, `.astro`, and `.astro-cache` removed beforehand.

## Safety

- the override is scoped to Vite's `prerender` environment, not client or deployed server output
- `assetFileNames` is not changed
- Rollup resolves duplicate chunk names with unique suffixes and rewrites internal imports accordingly
- explicit top-level or prerender-specific `entryFileNames`/`chunkFileNames` settings win

## Validation

- `pnpm --filter nimbus-docs typecheck`
- `pnpm --filter nimbus-docs test` (426 tests passed)
- full Cloudflare Docs cold builds completed with the same 8,708-page count and contents are the same (Except for randomly generated IDs)
