### PR TITLE
feat: full glob support for internal-link/image-ref ignore option

### DIFF
--- a/.changeset/spicy-otters-glow.md
+++ b/.changeset/spicy-otters-glow.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/nimbus-docs": minor
+---
+
+`nimbus/internal-link` and `nimbus/image-ref` now match their `ignore: string[]` option against full glob syntax (`**`, `*`, `{a,b}`, extglobs, …) via `picomatch`, not just an exact match or a `prefix` immediately followed by `/**`. In particular, a leading any-depth wildcard like `**/llms.txt` is now supported — the previous hand-rolled matcher had no way to express that.
+
+Existing `ignore` lists using only exact paths or `prefix/**` patterns keep working unchanged.

--- a/.changeset/tame-herons-jump.md
+++ b/.changeset/tame-herons-jump.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/create-nimbus-docs": patch
+---
+
+Bump for the `@cloudflare/nimbus-docs` minor in this release (full glob support for `ignore` in `internal-link`/`image-ref`) — no starter-source changes.

--- a/packages/nimbus-docs/package.json
+++ b/packages/nimbus-docs/package.json
@@ -101,6 +101,7 @@
 		"clsx": "^2.1.1",
 		"github-slugger": "^2.0.0",
 		"mri": "^1.2.0",
+		"picomatch": "^4.0.5",
 		"remark-lint-emphasis-marker": "^4.0.1",
 		"remark-lint-fenced-code-flag": "^4.2.0",
 		"remark-lint-heading-increment": "^4.0.1",
@@ -118,6 +119,7 @@
 	},
 	"devDependencies": {
 		"@mdx-js/mdx": "^3.1.1",
+		"@types/picomatch": "^4.0.3",
 		"@types/react": "^19.2.6",
 		"@types/react-dom": "^19.2.3",
 		"astro": "^7.0.0",

--- a/packages/nimbus-docs/src/_internal/ignore-glob.ts
+++ b/packages/nimbus-docs/src/_internal/ignore-glob.ts
@@ -1,32 +1,26 @@
 /**
- * Glob-based `ignore` matching for lint rules that accept an `ignore:
- * string[]` option (`internal-link`, `image-ref`). Backed by `picomatch` —
- * full glob syntax (`**`, `*`, `{a,b}`, `?`, extglobs, …), not just the
- * exact-match-or-`prefix/**`-suffix matcher this replaces.
+ * Glob matching for the `ignore: string[]` option (`internal-link`,
+ * `image-ref`). Backed by `picomatch` — full glob syntax (`**`, `*`,
+ * `{a,b}`, `?`, extglobs, …), not just exact match or `prefix/**`.
  *
- * The previous matcher was hand-rolled specifically to avoid the
- * `picomatch` dependency, and covered the common cases (`/api/**`,
- * `/changelog/**`) fine. It couldn't express an any-depth *leading*
- * wildcard — e.g. a two-star prefix immediately before `llms.txt` to match
- * that filename at any depth — though a real gap surfaced migrating a
- * site off `starlight-links-validator` (which validates the same shape of
- * `ignore` list via `picomatch` already), where the existing exclude list
- * had exactly that kind of pattern. Taking the dependency restores parity
- * with that prior tool's behavior rather than asking every migrating
- * project to flatten its exclude list down to what the minimal matcher
- * could express.
+ * Why picomatch, not hand-rolled:
+ * - Previous matcher covered `/api/**`, `/changelog/**` fine.
+ * - Couldn't express a leading any-depth wildcard (e.g. match `llms.txt`
+ *   at any depth).
+ * - Real gap: migrating off `starlight-links-validator` (already
+ *   picomatch-backed) — its exclude list used exactly that pattern.
+ * - Taking the dependency restores parity instead of flattening every
+ *   migrating project's exclude list to fit the minimal matcher.
  *
- * Compiled matchers are cached per *raw* `ctx.options.ignore` array identity
- * (`WeakMap`) — that array is the same reference for the lifetime of a lint
- * run (it comes straight from the resolved rule config, not a per-file
- * clone), so a run across thousands of files compiles each rule's `ignore`
- * list once, not once per file.
- *
- * Callers must pass the *unfiltered* `ctx.options.ignore` value straight
- * through (not a `.filter()`'d copy) — filtering happens in here, once per
- * distinct array, precisely so the cache key stays stable. A caller-side
- * `.filter()` would allocate a new array on every call and silently turn
- * this into a no-op cache (miss on every file).
+ * Caching contract:
+ * - Compiled matchers cached per *raw* `ctx.options.ignore` array identity
+ *   (`WeakMap`).
+ * - That array is the same reference for the life of a lint run (from
+ *   resolved rule config, not per-file).
+ * - So: one compile per run, not one per file.
+ * - Callers must pass the array through **unfiltered** — filtering happens
+ *   in here. A caller-side `.filter()` allocates a new array per call,
+ *   which breaks the cache key and silently turns this into a no-op cache.
  */
 
 import picomatch from "picomatch";
@@ -35,12 +29,8 @@ const cache = new WeakMap<object, (input: string) => boolean>();
 
 const NEVER_MATCH = (): boolean => false;
 
-/**
- * `dot: true` so patterns can match path segments that start with `.`
- * (e.g. `/.well-known/**`) — glob's dotfile convention doesn't apply to
- * URL paths, and a segment starting with `.` isn't meant to be hidden from
- * `**`/`*` here.
- */
+// `dot: true` — glob's dotfile convention doesn't apply to URL paths.
+// Without it, `/.well-known/**` wouldn't match its own segments.
 const PICOMATCH_OPTIONS = { dot: true } as const;
 
 function stripTrailingSlash(s: string): string {
@@ -48,14 +38,15 @@ function stripTrailingSlash(s: string): string {
 }
 
 /**
- * Match `url` (already run through the caller's own normalization — no
- * `base` prefix, no trailing slash, no hash/query) against the rule's raw
- * `ignore` option.
+ * Match `url` against the rule's raw `ignore` option.
  *
- * Patterns get their own trailing slash stripped before compiling, so an
- * old-style bare `"/api/"` entry (no `/**`) still matches `/api` exactly,
- * matching the previous matcher's behavior. Non-string entries are dropped
- * (same tolerance the old per-rule filtering had).
+ * - `url` must already be normalized by the caller (no `base` prefix, no
+ *   trailing slash, no hash/query).
+ * - Each pattern gets its trailing slash stripped before compiling, so a
+ *   bare `"/api/"` (no `/**`) still matches `/api` exactly — same as the
+ *   previous matcher.
+ * - Non-string entries are dropped (same tolerance the old per-rule
+ *   filtering had).
  */
 export function matchesAnyIgnore(url: string, rawIgnore: unknown): boolean {
   if (!Array.isArray(rawIgnore) || rawIgnore.length === 0) return false;

--- a/packages/nimbus-docs/src/_internal/ignore-glob.ts
+++ b/packages/nimbus-docs/src/_internal/ignore-glob.ts
@@ -1,0 +1,74 @@
+/**
+ * Glob-based `ignore` matching for lint rules that accept an `ignore:
+ * string[]` option (`internal-link`, `image-ref`). Backed by `picomatch` —
+ * full glob syntax (`**`, `*`, `{a,b}`, `?`, extglobs, …), not just the
+ * exact-match-or-`prefix/**`-suffix matcher this replaces.
+ *
+ * The previous matcher was hand-rolled specifically to avoid the
+ * `picomatch` dependency, and covered the common cases (`/api/**`,
+ * `/changelog/**`) fine. It couldn't express an any-depth *leading*
+ * wildcard — e.g. a two-star prefix immediately before `llms.txt` to match
+ * that filename at any depth — though a real gap surfaced migrating a
+ * site off `starlight-links-validator` (which validates the same shape of
+ * `ignore` list via `picomatch` already), where the existing exclude list
+ * had exactly that kind of pattern. Taking the dependency restores parity
+ * with that prior tool's behavior rather than asking every migrating
+ * project to flatten its exclude list down to what the minimal matcher
+ * could express.
+ *
+ * Compiled matchers are cached per *raw* `ctx.options.ignore` array identity
+ * (`WeakMap`) — that array is the same reference for the lifetime of a lint
+ * run (it comes straight from the resolved rule config, not a per-file
+ * clone), so a run across thousands of files compiles each rule's `ignore`
+ * list once, not once per file.
+ *
+ * Callers must pass the *unfiltered* `ctx.options.ignore` value straight
+ * through (not a `.filter()`'d copy) — filtering happens in here, once per
+ * distinct array, precisely so the cache key stays stable. A caller-side
+ * `.filter()` would allocate a new array on every call and silently turn
+ * this into a no-op cache (miss on every file).
+ */
+
+import picomatch from "picomatch";
+
+const cache = new WeakMap<object, (input: string) => boolean>();
+
+const NEVER_MATCH = (): boolean => false;
+
+/**
+ * `dot: true` so patterns can match path segments that start with `.`
+ * (e.g. `/.well-known/**`) — glob's dotfile convention doesn't apply to
+ * URL paths, and a segment starting with `.` isn't meant to be hidden from
+ * `**`/`*` here.
+ */
+const PICOMATCH_OPTIONS = { dot: true } as const;
+
+function stripTrailingSlash(s: string): string {
+  return s.length > 1 && s.endsWith("/") ? s.slice(0, -1) : s;
+}
+
+/**
+ * Match `url` (already run through the caller's own normalization — no
+ * `base` prefix, no trailing slash, no hash/query) against the rule's raw
+ * `ignore` option.
+ *
+ * Patterns get their own trailing slash stripped before compiling, so an
+ * old-style bare `"/api/"` entry (no `/**`) still matches `/api` exactly,
+ * matching the previous matcher's behavior. Non-string entries are dropped
+ * (same tolerance the old per-rule filtering had).
+ */
+export function matchesAnyIgnore(url: string, rawIgnore: unknown): boolean {
+  if (!Array.isArray(rawIgnore) || rawIgnore.length === 0) return false;
+  let isMatch = cache.get(rawIgnore);
+  if (!isMatch) {
+    const patterns = rawIgnore
+      .filter((s): s is string => typeof s === "string")
+      .map(stripTrailingSlash);
+    isMatch =
+      patterns.length === 0
+        ? NEVER_MATCH
+        : picomatch(patterns, PICOMATCH_OPTIONS);
+    cache.set(rawIgnore, isMatch);
+  }
+  return isMatch(url);
+}

--- a/packages/nimbus-docs/src/_internal/ignore-glob.ts
+++ b/packages/nimbus-docs/src/_internal/ignore-glob.ts
@@ -45,15 +45,16 @@ function stripTrailingSlash(s: string): string {
  * - Each pattern gets its trailing slash stripped before compiling, so a
  *   bare `"/api/"` (no `/**`) still matches `/api` exactly — same as the
  *   previous matcher.
- * - Non-string entries are dropped (same tolerance the old per-rule
- *   filtering had).
+ * - Non-string and empty-string entries are dropped — `picomatch("")`
+ *   throws, which would silently disable the whole rule (the engine skips a
+ *   throwing rule). The old matcher tolerated `""`; this keeps that.
  */
 export function matchesAnyIgnore(url: string, rawIgnore: unknown): boolean {
   if (!Array.isArray(rawIgnore) || rawIgnore.length === 0) return false;
   let isMatch = cache.get(rawIgnore);
   if (!isMatch) {
     const patterns = rawIgnore
-      .filter((s): s is string => typeof s === "string")
+      .filter((s): s is string => typeof s === "string" && s !== "")
       .map(stripTrailingSlash);
     isMatch =
       patterns.length === 0

--- a/packages/nimbus-docs/src/lint/README.md
+++ b/packages/nimbus-docs/src/lint/README.md
@@ -245,6 +245,21 @@ A near-match within Levenshtein distance 3 produces a "did you mean"
 hint via the same `_internal/levenshtein.ts:suggest` helper the
 PascalCase validator uses.
 
+**`ignore` — full glob syntax via `picomatch`.** Both `internal-link` and
+`image-ref` share `_internal/ignore-glob.ts` for matching their `ignore:
+string[]` option — `**`, `*`, `{a,b}`, extglobs, etc., not just an exact
+match or a `prefix` immediately followed by a two-star suffix. An earlier
+version hand-rolled just that two-case matcher specifically to avoid the
+`picomatch` dependency; it covered the common patterns (`/api/**`,
+`/changelog/**`) but couldn't express an any-depth *leading* wildcard
+(matching a given filename at any depth), which turned out to matter in
+practice migrating a site off `starlight-links-validator` (itself
+`picomatch`-backed) — its exclude list had exactly that shape of pattern.
+Compiled matchers are cached per `ignore` array identity, so a run
+compiles each rule's list once per lint run, not once per file — callers
+must pass the option through unfiltered for that cache to do anything
+(see the helper's own doc comment).
+
 **Deferred:**
 
 - `nimbus/internal-link-hash` (`#section-id` anchor validation) is its own

--- a/packages/nimbus-docs/src/lint/rules/image-ref.ts
+++ b/packages/nimbus-docs/src/lint/rules/image-ref.ts
@@ -24,6 +24,10 @@
  *   - External URLs (any scheme, incl. `data:`, and `//`) are skipped —
  *     remote existence checks are a network concern, not a lint.
  *   - Dynamic JSX attrs (`<img src={x}>`) are skipped — not checkable.
+ *   - `ignore: string[]` supports full glob syntax (`**`, `*`, `{a,b}`, …)
+ *     via `../../_internal/ignore-glob.js` (picomatch-backed), matched
+ *     against the cleaned URL (query/hash stripped, percent-decoded) —
+ *     same shape as `internal-link`'s option.
  *
  * A miss whose containing directory exists produces a "did you mean" hint
  * from that directory's entries via Levenshtein distance.
@@ -32,6 +36,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import { matchesAnyIgnore } from "../../_internal/ignore-glob.js";
 import { suggest } from "../../_internal/levenshtein.js";
 import { collect, startOf, visit, type MdNode } from "../parse.js";
 import type { Rule } from "../rule.js";
@@ -41,9 +46,11 @@ export const imageRef: Rule = {
   run(ctx) {
     const root = inferProjectRoot(ctx.file.absPath);
     const aliases = readAliases(ctx.options.aliases);
-    const ignore = Array.isArray(ctx.options.ignore)
-      ? ctx.options.ignore.filter((s): s is string => typeof s === "string")
-      : [];
+    // Passed through raw (not `.filter()`'d) — `matchesAnyIgnore` filters
+    // and compiles internally, keyed on this array's identity for its
+    // compiled-matcher cache. A `.filter()`'d copy here would allocate a
+    // new array per file and defeat that cache.
+    const ignore = ctx.options.ignore;
     const extraComponents = readExtraComponents(ctx.options.components);
     const definitions = collectDefinitions(ctx.file.tree);
 
@@ -274,26 +281,6 @@ function suggestSibling(fullPath: string): string | null {
     return null;
   }
   return suggest(path.basename(fullPath), new Set(entries), 3);
-}
-
-/**
- * Minimal glob matcher — exact match or `prefix/**` suffix, same shape as
- * `internal-link`'s. Patterns are authored against the raw cleaned URL
- * (e.g. `/images/generated/**`).
- */
-function matchesAnyIgnore(url: string, patterns: string[]): boolean {
-  if (patterns.length === 0) return false;
-  for (const pat of patterns) {
-    const stripped =
-      pat.length > 1 && pat.endsWith("/") ? pat.slice(0, -1) : pat;
-    if (stripped.endsWith("/**")) {
-      const prefix = stripped.slice(0, -3);
-      if (url === prefix || url.startsWith(`${prefix}/`)) return true;
-    } else if (url === stripped) {
-      return true;
-    }
-  }
-  return false;
 }
 
 /** Find the project root from a content file by walking up to the parent of `src`. */

--- a/packages/nimbus-docs/src/lint/rules/image-ref.ts
+++ b/packages/nimbus-docs/src/lint/rules/image-ref.ts
@@ -46,10 +46,9 @@ export const imageRef: Rule = {
   run(ctx) {
     const root = inferProjectRoot(ctx.file.absPath);
     const aliases = readAliases(ctx.options.aliases);
-    // Passed through raw (not `.filter()`'d) — `matchesAnyIgnore` filters
-    // and compiles internally, keyed on this array's identity for its
-    // compiled-matcher cache. A `.filter()`'d copy here would allocate a
-    // new array per file and defeat that cache.
+    // Pass through raw, unfiltered — `matchesAnyIgnore` caches its
+    // compiled matcher on this array's identity. Filtering here would
+    // break that cache (new array per file).
     const ignore = ctx.options.ignore;
     const extraComponents = readExtraComponents(ctx.options.components);
     const definitions = collectDefinitions(ctx.file.tree);

--- a/packages/nimbus-docs/src/lint/rules/internal-link.ts
+++ b/packages/nimbus-docs/src/lint/rules/internal-link.ts
@@ -26,6 +26,10 @@
  *     the truth for the root namespace.
  *   - A near-match in the route set produces a "did you mean" hint via
  *     Levenshtein distance — same pattern `component-pascalcase` uses.
+ *   - `ignore: string[]` supports full glob syntax (`**`, `*`, `{a,b}`, …)
+ *     via `../../_internal/ignore-glob.js` (picomatch-backed), matched
+ *     against the post-normalization URL (no `base` prefix, no trailing
+ *     slash, no hash/query) — author patterns against the site-root form.
  *
  * Relative links (`./foo`, `../bar`) error by default. `allowRelative: true`
  * silences them for projects that want to use them.
@@ -34,6 +38,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import { matchesAnyIgnore } from "../../_internal/ignore-glob.js";
 import { suggest } from "../../_internal/levenshtein.js";
 import {
   collect,
@@ -104,9 +109,11 @@ export const internalLink: Rule = {
     if (!truth) return;
 
     const allowRelative = ctx.options.allowRelative === true;
-    const ignore = Array.isArray(ctx.options.ignore)
-      ? ctx.options.ignore.filter((s): s is string => typeof s === "string")
-      : [];
+    // Passed through raw (not `.filter()`'d) — `matchesAnyIgnore` filters
+    // and compiles internally, keyed on this array's identity for its
+    // compiled-matcher cache. A `.filter()`'d copy here would allocate a
+    // new array per file and defeat that cache.
+    const ignore = ctx.options.ignore;
     const extraComponents = readExtraComponents(ctx.options.components);
 
     // Route truth is materialized from Astro's `pages` at `astro:build:done`
@@ -340,29 +347,6 @@ function isUnderOpaqueNamespace(
     if (ns === "/") return true;
     if (route === ns) return true;
     if (route.startsWith(`${ns}/`)) return true;
-  }
-  return false;
-}
-
-/**
- * Minimal glob matcher — exact match or `prefix/**` suffix. Covers the
- * common `ignore` patterns (`/api/**`, `/changelog/**`) without pulling
- * in picomatch. Input is the post-`normalizeForLookup` URL (no `base`
- * prefix, no trailing slash, no hash/query), so patterns are authored
- * against the canonical site-root form.
- */
-function matchesAnyIgnore(normalizedUrl: string, patterns: string[]): boolean {
-  if (patterns.length === 0) return false;
-  for (const pat of patterns) {
-    const stripped = stripTrailingSlash(pat);
-    if (stripped.endsWith("/**")) {
-      const prefix = stripped.slice(0, -3);
-      if (normalizedUrl === prefix || normalizedUrl.startsWith(`${prefix}/`)) {
-        return true;
-      }
-    } else if (normalizedUrl === stripped) {
-      return true;
-    }
   }
   return false;
 }

--- a/packages/nimbus-docs/src/lint/rules/internal-link.ts
+++ b/packages/nimbus-docs/src/lint/rules/internal-link.ts
@@ -109,10 +109,9 @@ export const internalLink: Rule = {
     if (!truth) return;
 
     const allowRelative = ctx.options.allowRelative === true;
-    // Passed through raw (not `.filter()`'d) — `matchesAnyIgnore` filters
-    // and compiles internally, keyed on this array's identity for its
-    // compiled-matcher cache. A `.filter()`'d copy here would allocate a
-    // new array per file and defeat that cache.
+    // Pass through raw, unfiltered — `matchesAnyIgnore` caches its
+    // compiled matcher on this array's identity. Filtering here would
+    // break that cache (new array per file).
     const ignore = ctx.options.ignore;
     const extraComponents = readExtraComponents(ctx.options.components);
 

--- a/packages/nimbus-docs/test/lint/image-ref.test.ts
+++ b/packages/nimbus-docs/test/lint/image-ref.test.ts
@@ -189,6 +189,28 @@ test("image-ref honors ignore globs", () => {
   }
 });
 
+test("image-ref ignore supports a leading any-depth wildcard and brace expansion", () => {
+  const setup = setupProject();
+  try {
+    const clean = lint(
+      setup,
+      `${FM}
+![thumb](/products/workers/thumbnail.webp)
+![thumb2](/products/r2/thumbnail2.webp)
+`,
+      { ignore: ["**/thumbnail.webp", "**/thumbnail2.webp"] },
+    );
+    assert.deepEqual(clean, []);
+
+    const broken = lint(setup, `${FM}\n![missing](/other/missing.png)\n`, {
+      ignore: ["**/thumbnail.webp", "**/thumbnail2.webp"],
+    });
+    assert.equal(broken.length, 1);
+  } finally {
+    cleanup(setup.root);
+  }
+});
+
 test("image-ref checks opt-in components", () => {
   const setup = setupProject(["public/frames/ok.png"]);
   try {

--- a/packages/nimbus-docs/test/lint/image-ref.test.ts
+++ b/packages/nimbus-docs/test/lint/image-ref.test.ts
@@ -211,6 +211,18 @@ test("image-ref ignore supports a leading any-depth wildcard and brace expansion
   }
 });
 
+test("image-ref ignore tolerates a stray empty-string pattern (no rule-wide crash)", () => {
+  const setup = setupProject();
+  try {
+    const broken = lint(setup, `${FM}\n![missing](/other/missing.png)\n`, {
+      ignore: ["**/thumbnail.webp", ""],
+    });
+    assert.equal(broken.length, 1);
+  } finally {
+    cleanup(setup.root);
+  }
+});
+
 test("image-ref checks opt-in components", () => {
   const setup = setupProject(["public/frames/ok.png"]);
   try {

--- a/packages/nimbus-docs/test/lint/internal-link.test.ts
+++ b/packages/nimbus-docs/test/lint/internal-link.test.ts
@@ -388,6 +388,107 @@ test("internal-link applies ignore against the post-base form (not the raw URL)"
   }
 });
 
+test("internal-link ignore supports a leading any-depth wildcard", () => {
+  // Matches "llms.txt" at any depth — the exact shape the old
+  // exact-match-or-`prefix/**` matcher couldn't express.
+  const leadingWildcard = "**/llms.txt";
+  const setup = setupProject(baseTruth());
+  try {
+    _resetInternalLinkCacheForTests();
+    const parsed = parseSource(
+      `${FM}
+# Title
+
+[root](/llms.txt) and [nested](/workers/llms.txt) both ignored,
+[flagged](/workers/llms-full.txt) is not.
+`,
+      {
+        path: "src/content/docs/page.mdx",
+        absPath: setup.pagePath,
+        collection: "docs",
+      },
+    );
+    const diags = lintFile(parsed, {
+      rules: {
+        "nimbus/internal-link": ["error", { ignore: [leadingWildcard] }],
+      },
+    }).filter((d) => d.code === "nimbus/internal-link");
+    assert.equal(diags.length, 1);
+    assert.match(diags[0]!.message, /broken link "\/workers\/llms-full\.txt"/);
+  } finally {
+    cleanup(setup.root);
+  }
+});
+
+test("internal-link ignore supports mid-segment wildcards and brace expansion", () => {
+  const setup = setupProject(baseTruth());
+  try {
+    _resetInternalLinkCacheForTests();
+    const parsed = parseSource(
+      `${FM}
+# Title
+
+[mid](/rules/snippets/examples) and [brace](/videos/en/intro) both ignored,
+[flagged](/rules/other/thing) is not.
+`,
+      {
+        path: "src/content/docs/page.mdx",
+        absPath: setup.pagePath,
+        collection: "docs",
+      },
+    );
+    const diags = lintFile(parsed, {
+      rules: {
+        "nimbus/internal-link": [
+          "error",
+          { ignore: ["/rules/{snippets,transform}/examples", "/videos/**"] },
+        ],
+      },
+    }).filter((d) => d.code === "nimbus/internal-link");
+    assert.equal(diags.length, 1);
+    assert.match(diags[0]!.message, /broken link "\/rules\/other\/thing"/);
+  } finally {
+    cleanup(setup.root);
+  }
+});
+
+test("internal-link ignore compiles a given pattern list once across files (cache correctness)", () => {
+  // Regression guard: `matchesAnyIgnore` caches its compiled matcher keyed
+  // on the *raw* `ignore` array's identity. Passing the exact same array
+  // reference across two separate `lintFile` calls (as the resolved rule
+  // config does across every file in a real run) must hit the cache and
+  // still produce correct results the second time, not a stale/empty one.
+  const setup = setupProject(baseTruth());
+  const ignore = ["/api/**"];
+  const rules = { "nimbus/internal-link": ["error", { ignore }] as const };
+  try {
+    _resetInternalLinkCacheForTests();
+    const first = parseSource(`${FM}\n[a](/api/foo) [b](/nope)\n`, {
+      path: "src/content/docs/page.mdx",
+      absPath: setup.pagePath,
+      collection: "docs",
+    });
+    const firstDiags = lintFile(first, { rules }).filter(
+      (d) => d.code === "nimbus/internal-link",
+    );
+    assert.equal(firstDiags.length, 1);
+    assert.match(firstDiags[0]!.message, /broken link "\/nope"/);
+
+    const second = parseSource(`${FM}\n[c](/api/bar) [d](/also-nope)\n`, {
+      path: "src/content/docs/page.mdx",
+      absPath: setup.pagePath,
+      collection: "docs",
+    });
+    const secondDiags = lintFile(second, { rules }).filter(
+      (d) => d.code === "nimbus/internal-link",
+    );
+    assert.equal(secondDiags.length, 1);
+    assert.match(secondDiags[0]!.message, /broken link "\/also-nope"/);
+  } finally {
+    cleanup(setup.root);
+  }
+});
+
 // ---------------------------------------------------------------------------
 // Missing route truth → silent skip
 // ---------------------------------------------------------------------------

--- a/packages/nimbus-docs/test/lint/internal-link.test.ts
+++ b/packages/nimbus-docs/test/lint/internal-link.test.ts
@@ -489,6 +489,30 @@ test("internal-link ignore compiles a given pattern list once across files (cach
   }
 });
 
+test("internal-link ignore tolerates a stray empty-string pattern (no rule-wide crash)", () => {
+  const setup = setupProject(baseTruth());
+  try {
+    _resetInternalLinkCacheForTests();
+    const parsed = parseSource(
+      `${FM}\n[ignored](/api/foo) [flagged](/nope)\n`,
+      {
+        path: "src/content/docs/page.mdx",
+        absPath: setup.pagePath,
+        collection: "docs",
+      },
+    );
+    const diags = lintFile(parsed, {
+      rules: {
+        "nimbus/internal-link": ["error", { ignore: ["/api/**", ""] }],
+      },
+    }).filter((d) => d.code === "nimbus/internal-link");
+    assert.equal(diags.length, 1);
+    assert.match(diags[0]!.message, /broken link "\/nope"/);
+  } finally {
+    cleanup(setup.root);
+  }
+});
+
 // ---------------------------------------------------------------------------
 // Missing route truth → silent skip
 // ---------------------------------------------------------------------------

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,9 @@ importers:
       mri:
         specifier: ^1.2.0
         version: 1.2.0
+      picomatch:
+        specifier: ^4.0.5
+        version: 4.0.5
       react:
         specifier: '>=19.0.0'
         version: 19.2.7
@@ -212,6 +215,9 @@ importers:
       '@mdx-js/mdx':
         specifier: ^3.1.1
         version: 3.1.1
+      '@types/picomatch':
+        specifier: ^4.0.3
+        version: 4.0.3
       '@types/react':
         specifier: ^19.2.6
         version: 19.2.17
@@ -2071,6 +2077,9 @@ packages:
 
   '@types/node@24.12.4':
     resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
+
+  '@types/picomatch@4.0.3':
+    resolution: {integrity: sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -6014,6 +6023,8 @@ snapshots:
   '@types/node@24.12.4':
     dependencies:
       undici-types: 7.16.0
+
+  '@types/picomatch@4.0.3': {}
 
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:


### PR DESCRIPTION
### What

- Replace hand-rolled `ignore` matcher (exact match or `prefix/**`) with `picomatch`
- Applies to both `nimbus/internal-link` and `nimbus/image-ref`
- Shared via new `_internal/ignore-glob.ts` (same pattern as `_internal/levenshtein.ts`)

### Why

Matches Starlight's link validator more closely, so migration is easier. There's also not really a great solution otherwise to pattern matching/ignoring against lots of files otherwise here.

Concrete example, straight from `cloudflare-docs`'s actual `starlight-links-validator` config before the Nimbus migration:

```
exclude: [
  ...
  "**/llms.txt",
  "**/index.md",
  ...
]
```

Both use a leading `**/` — "match this filename at any depth." The old matcher can't express that at all: it only understands a whole-segment exact match or a fixed `prefix` + `/**` suffix. There's no way to write "match `llms.txt` wherever it shows up" with it. `cloudflare-docs` actually needs this — `/llms.txt`, `/workers/llms.txt`, `/workers-ai/llms.txt`, etc. are all served per-product straight from the Worker (not real Astro page routes), so every one of them shows up as a broken link without an `ignore` entry covering all of them at once.

### Alternative considered

Open to extending the hand-rolled matcher for just the leading-wildcard case instead, if the dependency itself (not the specific gap) is the concern. Didn't default to that — it's rebuilding a glob engine one case at a time. picomatch is small, 0 dependency, so seems better to have it handle this for us, IMO.

@MohamedH1998 — let me know what you think here.

### Checklist

- [x] `pnpm typecheck` — green (root + both packages)
- [x] `pnpm -r test` — green (430/430 in `nimbus-docs`)
- [x] `pnpm templates:check` — green
- [x] Changeset added (minor)
- [x] Tests added: leading wildcard, mid-segment wildcard, brace expansion, cache-correctness regression
