### PR TITLE
chore: standardise scaffold command

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -8,3 +8,4 @@
 # Org owners, members, and collaborators are already exempt and don't belong here.
 
 matthewp  # direct add ahead of incoming PR, 2026-07-22
+ttmx      # direct add ahead of incoming contributions, 2026-07-22 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -12,7 +12,7 @@ labels: ["bug"]
 
 ### Reproduction
 
-<!-- Minimal steps — ideally from `examples/local` or a fresh `pnpm create @cloudflare/nimbus-docs`. Include the failing command and its output. -->
+<!-- Minimal steps — ideally from `examples/local` or a fresh `npx @cloudflare/create-nimbus-docs@latest`. Include the failing command and its output. -->
 
 1.
 2.

--- a/AGENT.md
+++ b/AGENT.md
@@ -22,7 +22,7 @@ monorepo/
 │   │   ├── src/                           components, layouts, pages (incl. pages/dev/), demo content
 │   │   ├── templates/                     per-variant content overrides (empty/, …)
 │   │   └── starter.manifest.mjs           declarative generation policy (registry-only slugs, dev-only paths, variants)
-│   └── create-nimbus-docs/                scaffolder (`pnpm create @cloudflare/nimbus-docs`) — CLI only, no templates
+│   └── create-nimbus-docs/                scaffolder (`npx @cloudflare/create-nimbus-docs`) — CLI only, no templates
 │       └── scripts/copy-template.mjs      generator: canonical source + manifest → variant dirs (--out)
 ├── apps/
 │   └── www/                               docs site + registry hosting

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ monorepo/
 │   │   ├── src/                           components, layouts, pages (incl. pages/dev/), demo content
 │   │   ├── templates/                     per-variant content overrides (empty/, …)
 │   │   └── starter.manifest.mjs           declarative generation policy (registry-only slugs, dev-only paths, variants)
-│   └── create-nimbus-docs/                scaffolder (`pnpm create @cloudflare/nimbus-docs`) — CLI only, no templates
+│   └── create-nimbus-docs/                scaffolder (`npx @cloudflare/create-nimbus-docs`) — CLI only, no templates
 │       └── scripts/copy-template.mjs      generator: canonical source + manifest → variant dirs (--out)
 ├── apps/
 │   └── www/                               docs site + registry hosting

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ pnpm dev
 
 Open the printed URL, edit anything under `src/`, and the page reloads. You now own a full docs site.
 
-The scaffolder asks a couple of questions (deploy target, starter or empty content). Skip them with `--yes`:
+The scaffolder asks a few questions (deploy target, package manager, starter or empty content). Skip them with `--yes`:
 
 ```sh
-pnpm create @cloudflare/nimbus-docs@latest my-docs --yes
+npx @cloudflare/create-nimbus-docs@latest my-docs --yes
 ```
 
-Prefer npm, yarn, or bun? Use them — the scaffolder follows whichever you ran it with.
+Interactive runs let you pick the package manager for your project. With `--yes` it defaults to npm — add `--package-manager pnpm` (or `yarn`/`bun`) to choose another.
 
 ## Everyday commands
 

--- a/packages/create-nimbus-docs/README.md
+++ b/packages/create-nimbus-docs/README.md
@@ -3,9 +3,7 @@
 Scaffolder for new Nimbus projects.
 
 ```sh
-pnpm create @cloudflare/nimbus-docs my-docs
-# or
-npm create @cloudflare/nimbus-docs@latest my-docs
+npx @cloudflare/create-nimbus-docs@latest my-docs
 ```
 
 Flags:

--- a/packages/create-nimbus-docs/package.json
+++ b/packages/create-nimbus-docs/package.json
@@ -6,7 +6,7 @@
     "access": "public"
   },
   "type": "module",
-  "description": "Scaffold a new Nimbus docs site. Used via `pnpm create @cloudflare/nimbus-docs` / `npm create @cloudflare/nimbus-docs`.",
+  "description": "Scaffold a new Nimbus docs site. Used via `npx @cloudflare/create-nimbus-docs@latest`.",
   "keywords": [
     "astro",
     "documentation",

--- a/packages/nimbus-docs/README.md
+++ b/packages/nimbus-docs/README.md
@@ -5,7 +5,7 @@ Astro integration, content schemas, data helpers (`getSidebar`, `getPrevNext`, `
 Most users install via the scaffolder:
 
 ```sh
-pnpm create @cloudflare/nimbus-docs my-docs
+npx @cloudflare/create-nimbus-docs@latest my-docs
 ```
 
 Subpaths:

--- a/packages/nimbus-starter-source/src/content/docs/components.mdx
+++ b/packages/nimbus-starter-source/src/content/docs/components.mdx
@@ -49,7 +49,7 @@ any MDX file without `import`:
 
 <Steps>
   <Step title="Install Nimbus">
-    Scaffold a new project with `npx @cloudflare/create-nimbus-docs@latest my-app`.
+    Scaffold a new project with `pnpm create @cloudflare/nimbus-docs my-app`.
   </Step>
   <Step title="Edit content">
     Write MDX files in `src/content/docs/`.

--- a/packages/nimbus-starter-source/src/content/docs/components.mdx
+++ b/packages/nimbus-starter-source/src/content/docs/components.mdx
@@ -49,7 +49,7 @@ any MDX file without `import`:
 
 <Steps>
   <Step title="Install Nimbus">
-    Scaffold a new project with `pnpm create @cloudflare/nimbus-docs my-app`.
+    Scaffold a new project with `npx @cloudflare/create-nimbus-docs@latest my-app`.
   </Step>
   <Step title="Edit content">
     Write MDX files in `src/content/docs/`.

--- a/scripts/local.mjs
+++ b/scripts/local.mjs
@@ -2,7 +2,7 @@
 /**
  * `pnpm local` — scaffold a Nimbus docs site against your local pre-release
  * framework code, so you can validate what real users experience running
- * `npm create @cloudflare/nimbus-docs`.
+ * `npx @cloudflare/create-nimbus-docs`.
  *
  * Modes:
  *   pnpm local           Interactive scaffold into apps/<name>/.


### PR DESCRIPTION
## What & why

Standardise scaffold command

## Checklist

- [ ] A maintainer approved this work (`lgtm+` on my issue or discussion), or I'm on the team
- [ ] Correct tier (framework / starter / registry) per the boundary test
- [ ] Edited `packages/nimbus-starter-source/`, not the `templates` branch
- [ ] Changeset added (`create-nimbus-docs` changeset if the starter changed)
- [ ] `pnpm typecheck`, `pnpm -r test`, and `pnpm templates:check` all green

<details>
<summary>First time here?</summary>

Nimbus works from issues and discussions, not drive-by PRs, so unapproved PRs from
outside the team are closed automatically. If that's you, open an
[issue](https://github.com/cloudflare/nimbus/issues/new/choose) (bug or fix proposal)
or a [discussion](https://github.com/cloudflare/nimbus/discussions) (feature) instead —
once a maintainer approves you there, your PRs stay open. See
[CONTRIBUTING.md](https://github.com/cloudflare/nimbus/blob/main/CONTRIBUTING.md).

</details>
