### PR TITLE
Test Astro incremental static builds (preview)

### DIFF
--- a/apps/www/astro.config.ts
+++ b/apps/www/astro.config.ts
@@ -37,6 +37,12 @@ const nimbusConfig = defineNimbusConfig({
 
 export default defineConfig({
   output: "static",
+  // Testing Astro's experimental incremental static builds
+  // (withastro/astro#17084). Docs routes opt in via a per-entry `cacheKey`
+  // returned from `getDocsStaticPaths`/`getCollectionStaticPaths`.
+  experimental: {
+    incrementalBuild: true,
+  },
   integrations: [icon(), react(), nimbus(nimbusConfig)],
   vite: {
     // Tailwind v4 via its Vite plugin (replaces the PostCSS plugin, which

--- a/package.json
+++ b/package.json
@@ -23,6 +23,11 @@
   "engines": {
     "node": ">=22.12.0"
   },
+  "pnpm": {
+    "overrides": {
+      "astro": "https://pkg.pr.new/astro@17084"
+    }
+  },
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.31.0",

--- a/packages/nimbus-docs/src/_internal/content.ts
+++ b/packages/nimbus-docs/src/_internal/content.ts
@@ -13,10 +13,58 @@
  * derives its list from `sidebar.items` references.
  */
 
+import { createHash } from "node:crypto";
+
 import type { CollectionEntry } from "astro:content";
 
 /** Primary collection name. Hard-coded — see also `getDocsStaticPaths`. */
 const PRIMARY_COLLECTION = "docs";
+
+/**
+ * Content-derived `cacheKey` for Astro's experimental incremental static
+ * builds (`experimental.incrementalBuild`). Returned from `getStaticPaths`,
+ * it lets Astro skip re-rendering a page when neither the key nor the page's
+ * module dependency graph changed since the last build.
+ *
+ * The key hashes only the entry's *own* content — id, raw body, and
+ * frontmatter `data`. Component/layout changes are covered separately by
+ * Astro's dependency-graph hash, so they intentionally don't feed in here.
+ *
+ * We hash body+data rather than reading a loader-provided `entry.digest`
+ * because `digest` isn't part of the public `CollectionEntry` type (it
+ * depends on the loader), whereas body+data is always present and keeps the
+ * framework's `tsc` build clean.
+ */
+export function entryCacheKey(entry: CollectionEntry<string>): string {
+  const hash = createHash("sha256");
+  hash.update(entry.collection);
+  hash.update("\0");
+  hash.update(entry.id);
+  hash.update("\0");
+  hash.update(entry.body ?? "");
+  hash.update("\0");
+  hash.update(stableStringify(entry.data ?? {}));
+  return hash.digest("hex");
+}
+
+/**
+ * Deterministic JSON serialization with sorted object keys, so a `cacheKey`
+ * doesn't churn when a loader emits frontmatter fields in a different order
+ * between builds.
+ */
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, val) => {
+    if (val && typeof val === "object" && !Array.isArray(val)) {
+      return Object.keys(val as Record<string, unknown>)
+        .sort()
+        .reduce<Record<string, unknown>>((acc, key) => {
+          acc[key] = (val as Record<string, unknown>)[key];
+          return acc;
+        }, {});
+    }
+    return val;
+  });
+}
 
 /**
  * Return visible entries from one or more collections. Drafts are

--- a/packages/nimbus-docs/src/index.ts
+++ b/packages/nimbus-docs/src/index.ts
@@ -21,6 +21,7 @@ import {
   getVisibleEntries,
   getVisibleEntriesByCollection,
   clearContentCaches,
+  entryCacheKey,
 } from "./_internal/content.js";
 import {
   applyOverviewLeaf,
@@ -927,6 +928,9 @@ export const getDocsStaticPaths: GetStaticPaths = async () => {
   return entries.map((entry) => ({
     params: { slug: entry.id },
     props: { entry },
+    // Opt this route into Astro's experimental incremental static builds.
+    // Ignored unless `experimental.incrementalBuild` is enabled.
+    cacheKey: entryCacheKey(entry),
   }));
 };
 
@@ -1011,6 +1015,8 @@ export function getCollectionStaticPaths(collection: string): GetStaticPaths {
     return entries.map((entry) => ({
       params: { slug: entry.id },
       props: { entry },
+      // See `getDocsStaticPaths` — opt into experimental incremental builds.
+      cacheKey: entryCacheKey(entry),
     }));
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  astro: https://pkg.pr.new/astro@17084
+
 importers:
 
   .:
@@ -42,8 +45,8 @@ importers:
         specifier: ^2.6.2
         version: 2.6.2
       astro:
-        specifier: ^7.0.0
-        version: 7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.3)(yaml@2.9.0)
+        specifier: https://pkg.pr.new/astro@17084
+        version: https://pkg.pr.new/astro@17084(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.3)(yaml@2.9.0)
       astro-icon:
         specifier: ^1.1.0
         version: 1.1.5
@@ -71,7 +74,7 @@ importers:
         version: 0.9.9(prettier@3.8.4)(typescript@5.9.3)
       '@astrojs/mdx':
         specifier: ^7.0.3
-        version: 7.0.3(@astrojs/markdown-satteri@0.3.4)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.3)(yaml@2.9.0))
+        version: 7.0.3(@astrojs/markdown-satteri@0.3.4)(astro@https://pkg.pr.new/astro@17084(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.3)(yaml@2.9.0))
       '@tailwindcss/vite':
         specifier: ^4.1.4
         version: 4.3.3(vite@8.1.5(@types/node@20.19.41)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
@@ -135,7 +138,7 @@ importers:
         version: 0.3.4
       '@astrojs/mdx':
         specifier: ^7.0.3
-        version: 7.0.3(@astrojs/markdown-satteri@0.3.4)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.3)(yaml@2.9.0))
+        version: 7.0.3(@astrojs/markdown-satteri@0.3.4)(astro@https://pkg.pr.new/astro@17084(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.3)(yaml@2.9.0))
       '@astrojs/sitemap':
         specifier: ^3.7.2
         version: 3.7.3
@@ -219,8 +222,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
       astro:
-        specifier: ^7.0.0
-        version: 7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.3)(yaml@2.9.0)
+        specifier: https://pkg.pr.new/astro@17084
+        version: https://pkg.pr.new/astro@17084(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.3)(yaml@2.9.0)
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
@@ -252,14 +255,14 @@ importers:
         specifier: ^1.2.0
         version: 1.2.2
       astro:
-        specifier: ^7.0.0
-        version: 7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.3)(yaml@2.9.0)
+        specifier: https://pkg.pr.new/astro@17084
+        version: https://pkg.pr.new/astro@17084(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.3)(yaml@2.9.0)
       astro-icon:
         specifier: ^1.1.0
         version: 1.1.5
       astro-og-canvas:
         specifier: ^0.13.0
-        version: 0.13.0(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.3)(yaml@2.9.0))
+        version: 0.13.0(astro@https://pkg.pr.new/astro@17084(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.3)(yaml@2.9.0))
       canvaskit-wasm:
         specifier: ^0.41.1
         version: 0.41.1
@@ -414,10 +417,11 @@ packages:
 
   '@astrojs/mdx@7.0.3':
     resolution: {integrity: sha512-RxyIwU0uFam5ftwqKOjpIdhnFxZ/kEikeimLyQy3eGXbHT8WgRGzzesOIHVU8+m9TY8ag5WVOyvV24/GyqPdPQ==}
+    version: 7.0.3
     engines: {node: '>=22.12.0'}
     peerDependencies:
       '@astrojs/markdown-satteri': ^0.3.1
-      astro: ^7.0.0
+      astro: https://pkg.pr.new/astro@17084
     peerDependenciesMeta:
       '@astrojs/markdown-satteri':
         optional: true
@@ -2212,11 +2216,13 @@ packages:
 
   astro-og-canvas@0.13.0:
     resolution: {integrity: sha512-jcIDhE9OGIbd7LstZQ4CyzOpbbEKAlxJqEgdkVu6r26m7yJKlQjKysszfDxlox717cnCLPXKivyFjsufcq8sYA==}
+    version: 0.13.0
     peerDependencies:
-      astro: ^5.0.0 || ^6.0.0 || ^7.0.0
+      astro: https://pkg.pr.new/astro@17084
 
-  astro@7.1.3:
-    resolution: {integrity: sha512-4dhPyAAXthf3xLEYnG8SeL7yr/nTPPABfY7e9YF0yuO+vK9Xp+8Q5j4xzsmL3GueukQv4oNwGNTBepLOiDGeJA==}
+  astro@https://pkg.pr.new/astro@17084:
+    resolution: {tarball: https://pkg.pr.new/astro@17084}
+    version: 7.1.3
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
     peerDependencies:
@@ -3055,6 +3061,9 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magic-string@1.1.0:
+    resolution: {integrity: sha512-kS3VHe0nEPST2saQV4Rbkchcd3UBRkVTQHo1D3h/ZTwFDhai/mfKkmtPAtD129EOI7K3HlHIsFOt0WrI2/oU9g==}
 
   magicast@0.5.3:
     resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
@@ -4549,13 +4558,13 @@ snapshots:
       hast-util-from-html: 2.0.3
       satteri: 0.9.5
 
-  '@astrojs/mdx@7.0.3(@astrojs/markdown-satteri@0.3.4)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.3)(yaml@2.9.0))':
+  '@astrojs/mdx@7.0.3(@astrojs/markdown-satteri@0.3.4)(astro@https://pkg.pr.new/astro@17084(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@astrojs/internal-helpers': 0.10.1
       '@astrojs/markdown-remark': 7.2.1
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.3)(yaml@2.9.0)
+      astro: https://pkg.pr.new/astro@17084(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.3)(yaml@2.9.0)
       es-module-lexer: 2.1.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -5359,7 +5368,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.10.0
+      '@emnapi/runtime': 1.11.1
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -6170,14 +6179,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  astro-og-canvas@0.13.0(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.3)(yaml@2.9.0)):
+  astro-og-canvas@0.13.0(astro@https://pkg.pr.new/astro@17084(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
-      astro: 7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.3)(yaml@2.9.0)
+      astro: https://pkg.pr.new/astro@17084(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.3)(yaml@2.9.0)
       canvaskit-wasm: 0.41.1
       deterministic-object-hash: 2.0.2
       entities: 8.0.0
 
-  astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.3)(yaml@2.9.0):
+  astro@https://pkg.pr.new/astro@17084(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler-rs': 0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@astrojs/internal-helpers': 0.10.1
@@ -6207,7 +6216,7 @@ snapshots:
       http-cache-semantics: 4.2.0
       js-yaml: 4.1.1
       jsonc-parser: 3.3.1
-      magic-string: 0.30.21
+      magic-string: 1.1.0
       magicast: 0.5.3
       mrmime: 2.0.1
       neotraverse: 1.0.1
@@ -7166,6 +7175,10 @@ snapshots:
       yallist: 3.1.1
 
   magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magic-string@1.1.0:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 


### PR DESCRIPTION
Trying out Astro's experimental incremental static builds ([withastro/astro#17084](https://github.com/withastro/astro/pull/17084)) against `apps/www`.

- Pin the `astro#17084` preview build via root `pnpm.overrides`.
- Enable `experimental.incrementalBuild` in `apps/www`.
- Emit a content-derived `cacheKey` from `getDocsStaticPaths` / `getCollectionStaticPaths`.

Verified: no-op rebuild caches all 33 docs pages; editing one doc re-renders only that page.

**Not for merge** — pins a PR preview and has no `create-nimbus-docs` changeset.
