### PR TITLE
fix(styles): apply border-radius to table corners to prevent background overflow

### DIFF
--- a/packages/nimbus-starter-source/src/styles/prose.css
+++ b/packages/nimbus-starter-source/src/styles/prose.css
@@ -207,6 +207,22 @@
   border-bottom: none;
 }
 
+.docs-content :where(thead:not([class]) tr:not([class]):first-child th:not([class]):first-child) {
+  border-top-left-radius: calc(0.75rem - 1px);
+}
+
+.docs-content :where(thead:not([class]) tr:not([class]):first-child th:not([class]):last-child) {
+  border-top-right-radius: calc(0.75rem - 1px);
+}
+
+.docs-content :where(tbody:not([class]) tr:not([class]):last-child td:not([class]):first-child) {
+  border-bottom-left-radius: calc(0.75rem - 1px);
+}
+
+.docs-content :where(tbody:not([class]) tr:not([class]):last-child td:not([class]):last-child) {
+  border-bottom-right-radius: calc(0.75rem - 1px);
+}
+
 .docs-content :where(a:not([class])) {
   color: var(--nb-foreground);
   text-decoration-line: underline;


### PR DESCRIPTION
## Description
Fixes #53.

This PR resolves a visual issue where the background color of the `<thead>` corner `<th>` elements and the `<tbody>` last row corner `<td>` elements would overflow past the rounded corners of the table border. 

A `border-radius` of `.75rem` (adjusted with `calc(0.75rem - 1px)` for the `1px` border width) has been explicitly applied to these inner elements to ensure they match the outer table's rounding perfectly.

## Changes
- Applied `border-top-left-radius` and `border-top-right-radius` to the first and last `th` elements in the `thead`.
- Applied `border-bottom-left-radius` and `border-bottom-right-radius` to the first and last `td` elements in the last `tr` of the `tbody`.
