### PR TITLE
perf: hashless prerender bundles

### DIFF
--- a/.changeset/hashless-prerender-chunks.md
+++ b/.changeset/hashless-prerender-chunks.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/nimbus-docs": patch
+---
+
+Skip hashing Astro's temporary prerender bundle to speed up large builds. Astro imports that bundle to render the static pages and then deletes it, so hashing its thousands of lazy content chunks is wasted work — Rolldown re-walks the transitive chunk graph once per hash placeholder. The integration now gives those throwaway JS chunks deterministic, hashless names in the prerender environment only; shipped client and asset hashes are unchanged. On the Cloudflare Docs build (~8.7k pages) an isolated A/B measured ~30% less wall time (7:44 → 5:24). The override writes Astro 7's native `rolldownOptions` key and stays out of the way entirely if a consumer has configured the prerender environment's output themselves.

--- a/packages/nimbus-docs/src/_internal/prerender-chunk-names.ts
+++ b/packages/nimbus-docs/src/_internal/prerender-chunk-names.ts
@@ -1,0 +1,44 @@
+/**
+ * Hashless naming for Astro's temporary prerender bundle. Astro imports it to
+ * render static pages, then deletes it; on large sites, hashing its thousands of
+ * lazy chunks makes Rolldown re-walk the chunk graph per hash placeholder and
+ * dominates the build. Asset hashes are untouched — only throwaway JS names change.
+ */
+
+interface BuildOutputConfig {
+  rollupOptions?: { output?: unknown };
+  rolldownOptions?: { output?: unknown };
+}
+
+export interface PrerenderNamingInput {
+  environments?: { prerender?: { build?: BuildOutputConfig } };
+}
+
+export interface PrerenderOutputOverride {
+  entryFileNames: string;
+  chunkFileNames: string;
+}
+
+export const PRERENDER_ENTRY_FILE_NAME = "prerender-entry.mjs";
+export const PRERENDER_CHUNK_FILE_NAME = "chunks/[name].mjs";
+
+/**
+ * Hashless override for the prerender environment, or `null` when the consumer
+ * already configured that environment's output (via either key) and we must stay
+ * out of the way. Only the prerender env matters: Astro does not inherit
+ * top-level `build.output` into the prerender bundle, and writing our native
+ * `rolldownOptions` beside a consumer's `rollupOptions` would make Vite's
+ * `rolldownOptions ??= rollupOptions` drop theirs.
+ */
+export function resolvePrerenderChunkNames(
+  vite: PrerenderNamingInput | undefined,
+): PrerenderOutputOverride | null {
+  const build = vite?.environments?.prerender?.build;
+  const consumerOutput = build?.rolldownOptions?.output ?? build?.rollupOptions?.output;
+  if (consumerOutput !== undefined) return null;
+
+  return {
+    entryFileNames: PRERENDER_ENTRY_FILE_NAME,
+    chunkFileNames: PRERENDER_CHUNK_FILE_NAME,
+  };
+}

--- a/packages/nimbus-docs/src/integration.ts
+++ b/packages/nimbus-docs/src/integration.ts
@@ -45,6 +45,7 @@ import type {
 import sitemap from "@astrojs/sitemap";
 import { admonitionPlugin } from "./_internal/admonition-vite-plugin.js";
 import { parseComponentsRegistry } from "./_internal/parse-components-registry.js";
+import { resolvePrerenderChunkNames } from "./_internal/prerender-chunk-names.js";
 import {
   validateLintOptions,
   type CollectionsConfig,
@@ -559,37 +560,9 @@ export function nimbus(
           );
         }
 
-        // Astro's prerender bundle is temporary: it is imported to render the
-        // static pages and then deleted. Hashing its thousands of lazy content
-        // chunks can dominate large documentation builds because Rollup walks
-        // the transitive chunk graph once per hash placeholder. Keep asset
-        // hashes (they are copied to the final site), but use deterministic,
-        // hashless names for the temporary JavaScript chunks. Rollup resolves
-        // duplicate `[name]` values with stable numeric suffixes.
-        //
-        // Respect either environment-specific or inherited top-level output
-        // naming supplied by the consumer. Output arrays are uncommon for an
-        // Astro app and cannot be safely overlaid with an object, so leave them
-        // untouched as well.
-        const topLevelOutput = astroConfig.vite?.build?.rollupOptions?.output;
-        const prerenderOutput = astroConfig.vite?.environments?.prerender?.build
-          ?.rollupOptions?.output;
-        const canDefaultPrerenderNames =
-          !Array.isArray(topLevelOutput) && !Array.isArray(prerenderOutput);
-        const topLevelOutputOptions = canDefaultPrerenderNames ? topLevelOutput : undefined;
-        const prerenderOutputOptions = canDefaultPrerenderNames ? prerenderOutput : undefined;
-        const hashlessPrerenderOutput = canDefaultPrerenderNames
-          ? {
-              ...(topLevelOutputOptions?.entryFileNames === undefined &&
-              prerenderOutputOptions?.entryFileNames === undefined
-                ? { entryFileNames: "prerender-entry.mjs" }
-                : {}),
-              ...(topLevelOutputOptions?.chunkFileNames === undefined &&
-              prerenderOutputOptions?.chunkFileNames === undefined
-                ? { chunkFileNames: "chunks/[name].mjs" }
-                : {}),
-            }
-          : null;
+        // Hashless names for Astro's throwaway prerender bundle — skips
+        // Rolldown's per-chunk hash-graph walk on large builds (see helper).
+        const hashlessPrerenderOutput = resolvePrerenderChunkNames(astroConfig.vite);
 
         updateConfig({
           // Bridge `nimbusConfig.site` → Astro's top-level `site`. The
@@ -694,13 +667,14 @@ export function nimbus(
           //      the llms.txt routes) and the versioning alternates
           //      table.
           vite: {
-            ...(hashlessPrerenderOutput &&
-            Object.keys(hashlessPrerenderOutput).length > 0
+            ...(hashlessPrerenderOutput
               ? {
                   environments: {
                     prerender: {
+                      // Native Rolldown key (Astro 7); avoids Vite's
+                      // deprecation-track `rollupOptions` alias.
                       build: {
-                        rollupOptions: { output: hashlessPrerenderOutput },
+                        rolldownOptions: { output: hashlessPrerenderOutput },
                       },
                     },
                   },

--- a/packages/nimbus-docs/src/integration.ts
+++ b/packages/nimbus-docs/src/integration.ts
@@ -559,6 +559,38 @@ export function nimbus(
           );
         }
 
+        // Astro's prerender bundle is temporary: it is imported to render the
+        // static pages and then deleted. Hashing its thousands of lazy content
+        // chunks can dominate large documentation builds because Rollup walks
+        // the transitive chunk graph once per hash placeholder. Keep asset
+        // hashes (they are copied to the final site), but use deterministic,
+        // hashless names for the temporary JavaScript chunks. Rollup resolves
+        // duplicate `[name]` values with stable numeric suffixes.
+        //
+        // Respect either environment-specific or inherited top-level output
+        // naming supplied by the consumer. Output arrays are uncommon for an
+        // Astro app and cannot be safely overlaid with an object, so leave them
+        // untouched as well.
+        const topLevelOutput = astroConfig.vite?.build?.rollupOptions?.output;
+        const prerenderOutput = astroConfig.vite?.environments?.prerender?.build
+          ?.rollupOptions?.output;
+        const canDefaultPrerenderNames =
+          !Array.isArray(topLevelOutput) && !Array.isArray(prerenderOutput);
+        const topLevelOutputOptions = canDefaultPrerenderNames ? topLevelOutput : undefined;
+        const prerenderOutputOptions = canDefaultPrerenderNames ? prerenderOutput : undefined;
+        const hashlessPrerenderOutput = canDefaultPrerenderNames
+          ? {
+              ...(topLevelOutputOptions?.entryFileNames === undefined &&
+              prerenderOutputOptions?.entryFileNames === undefined
+                ? { entryFileNames: "prerender-entry.mjs" }
+                : {}),
+              ...(topLevelOutputOptions?.chunkFileNames === undefined &&
+              prerenderOutputOptions?.chunkFileNames === undefined
+                ? { chunkFileNames: "chunks/[name].mjs" }
+                : {}),
+            }
+          : null;
+
         updateConfig({
           // Bridge `nimbusConfig.site` → Astro's top-level `site`. The
           // sitemap integration and `Astro.site` both read this; without
@@ -662,6 +694,18 @@ export function nimbus(
           //      the llms.txt routes) and the versioning alternates
           //      table.
           vite: {
+            ...(hashlessPrerenderOutput &&
+            Object.keys(hashlessPrerenderOutput).length > 0
+              ? {
+                  environments: {
+                    prerender: {
+                      build: {
+                        rollupOptions: { output: hashlessPrerenderOutput },
+                      },
+                    },
+                  },
+                }
+              : {}),
             plugins: [
               ...admonitionVitePlugins,
               virtualConfigPlugin(config, {

--- a/packages/nimbus-docs/test/integration-prerender-output.test.ts
+++ b/packages/nimbus-docs/test/integration-prerender-output.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Wiring guard: `astro:config:setup` must write the hashless prerender naming to
+ * the NATIVE `vite.environments.prerender.build.rolldownOptions.output` (the key
+ * Astro 7 reads), and must NOT touch it when the consumer already configured that
+ * environment. A silent key regression here would quietly lose the build-time win
+ * on large sites, so pin it end-to-end rather than only unit-testing the helper.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { mkdtemp, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import nimbus from "../src/index.js";
+import {
+  PRERENDER_ENTRY_FILE_NAME,
+  PRERENDER_CHUNK_FILE_NAME,
+} from "../src/_internal/prerender-chunk-names.js";
+
+const dirUrl = (p: string) => pathToFileURL(p + path.sep);
+
+async function fixture() {
+  const root = await mkdtemp(path.join(tmpdir(), "nimbus-prerender-"));
+  const write = async (rel: string, body: string) => {
+    const full = path.join(root, rel);
+    await mkdir(path.dirname(full), { recursive: true });
+    await writeFile(full, body, "utf8");
+  };
+  await write("src/content/docs/index.md", "---\ntitle: Home\ndescription: D\n---\n\nHi.\n");
+  await write(
+    "src/content.config.ts",
+    `import { docsCollection } from "@cloudflare/nimbus-docs/content";\nexport const collections = { docs: docsCollection({ base: "docs" }) };\n`,
+  );
+  await write("src/components.ts", "export const components = {\n  Aside: () => null,\n};\n");
+  return root;
+}
+
+async function runConfigSetup(root: string, vite?: Record<string, unknown>) {
+  const logger = {
+    warn: () => {},
+    info: () => {},
+    error: () => {},
+    debug: () => {},
+    fork() {
+      return logger;
+    },
+  };
+  let updatedConfig: Record<string, any> | null = null;
+
+  const integration = nimbus(
+    { site: "https://example.test", title: "T", description: "D", locale: "en" } as never,
+    { validateMdx: false, admonitions: false, sitemap: false, markdown: { processor: {} as never } },
+  );
+  const hook = integration.hooks["astro:config:setup"];
+  assert.ok(hook, "integration exposes astro:config:setup");
+
+  await hook!({
+    updateConfig: (config: Record<string, unknown>) => {
+      updatedConfig = config;
+      return {} as never;
+    },
+    config: {
+      root: dirUrl(root),
+      srcDir: dirUrl(path.join(root, "src")),
+      cacheDir: dirUrl(path.join(root, ".cache")),
+      base: "",
+      ...(vite ? { vite } : {}),
+    },
+    logger,
+  } as never);
+
+  return updatedConfig;
+}
+
+const prerenderOutput = (cfg: Record<string, any> | null) =>
+  cfg?.vite?.environments?.prerender?.build?.rolldownOptions?.output;
+
+test("writes hashless names to the native rolldownOptions key when unconfigured", async () => {
+  const root = await fixture();
+  const updated = await runConfigSetup(root);
+  assert.deepEqual(prerenderOutput(updated), {
+    entryFileNames: PRERENDER_ENTRY_FILE_NAME,
+    chunkFileNames: PRERENDER_CHUNK_FILE_NAME,
+  });
+});
+
+test("does not touch the prerender env when the consumer already configured its output", async () => {
+  const root = await fixture();
+  const updated = await runConfigSetup(root, {
+    environments: {
+      prerender: { build: { rolldownOptions: { output: { entryFileNames: "mine-[hash].mjs" } } } },
+    },
+  });
+  // Guard against a vacuous pass: the hook must have run and produced a vite
+  // config — it just must not add a competing prerender output block.
+  assert.ok(updated?.vite?.plugins, "config:setup should update vite");
+  assert.equal(updated?.vite?.environments, undefined);
+});

--- a/packages/nimbus-docs/test/prerender-chunk-names.test.ts
+++ b/packages/nimbus-docs/test/prerender-chunk-names.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  resolvePrerenderChunkNames,
+  PRERENDER_ENTRY_FILE_NAME,
+  PRERENDER_CHUNK_FILE_NAME,
+} from "../src/_internal/prerender-chunk-names.js";
+
+const BOTH = {
+  entryFileNames: PRERENDER_ENTRY_FILE_NAME,
+  chunkFileNames: PRERENDER_CHUNK_FILE_NAME,
+};
+
+test("defaults hashless names when nothing is configured", () => {
+  assert.deepEqual(resolvePrerenderChunkNames({}), BOTH);
+});
+
+test("defaults hashless names when the whole vite config is undefined", () => {
+  assert.deepEqual(resolvePrerenderChunkNames(undefined), BOTH);
+});
+
+test("ignores top-level output — Astro never inherits it into the prerender bundle", () => {
+  // A top-level output config is irrelevant to the prerender env, so it must not
+  // suppress the optimization.
+  const out = resolvePrerenderChunkNames({
+    // @ts-expect-error - top-level build is intentionally not part of the input type
+    build: { rolldownOptions: { output: { entryFileNames: "top-[hash].js" } } },
+  });
+  assert.deepEqual(out, BOTH);
+});
+
+test("bails when the consumer configured the prerender env via rolldownOptions", () => {
+  const out = resolvePrerenderChunkNames({
+    environments: {
+      prerender: { build: { rolldownOptions: { output: { entryFileNames: "e.mjs" } } } },
+    },
+  });
+  assert.equal(out, null);
+});
+
+test("bails when the consumer configured the prerender env via the rollupOptions alias", () => {
+  // The M1 case: writing our native rolldownOptions here would make Vite drop
+  // the consumer's rollupOptions. Staying out entirely is the only safe move.
+  const out = resolvePrerenderChunkNames({
+    environments: {
+      prerender: { build: { rollupOptions: { output: { entryFileNames: "keep-[hash].mjs" } } } },
+    },
+  });
+  assert.equal(out, null);
+});
+
+test("bails on a prerender-env output array", () => {
+  const out = resolvePrerenderChunkNames({
+    environments: { prerender: { build: { rolldownOptions: { output: [{}] } } } },
+  });
+  assert.equal(out, null);
+});
+
+test("bails on an empty-but-present prerender-env output object", () => {
+  const out = resolvePrerenderChunkNames({
+    environments: { prerender: { build: { rollupOptions: { output: {} } } } },
+  });
+  assert.equal(out, null);
+});


### PR DESCRIPTION
## What & why

Skip hashing Astro's temporary prerender bundle - shout out @ttmx for this

Speeds up large docs builds by giving Astro's throwaway **prerender** bundle
hashless filenames, so Rolldown skips its per-chunk hash-graph walk.

### Why

Astro imports the prerender bundle to render static pages, then deletes it. On
large sites, hashing its thousands of lazy content chunks dominates the build —
Rolldown re-walks the transitive chunk graph once per hash placeholder, which is
wasted work on an intermediate that's thrown away.

Cloudflare Docs (~8.7k pages), isolated cold-build A/B:

| | Wall time | Prerender bundling |
| --- | ---: | ---: |
| Before (hashed) | 7:44 | 3:51 |
| After (hashless) | 5:24 | 1:39 |

~30% less wall time, ~57% less prerender bundling.

### What
- Hashless entry/chunk names for the **prerender environment only** — shipped
  client and asset hashes are unchanged.
- Writes Astro 7's native `rolldownOptions` output key, not the
  deprecation-track `rollupOptions` alias.
- Stays out of the way

## Checklist

- [ ] A maintainer approved this work (`lgtm+` on my issue or discussion), or I'm on the team
- [ ] Correct tier (framework / starter / registry) per the boundary test
- [ ] Edited `packages/nimbus-starter-source/`, not the `templates` branch
- [ ] Changeset added (`create-nimbus-docs` changeset if the starter changed)
- [ ] `pnpm typecheck`, `pnpm -r test`, and `pnpm templates:check` all green

<details>
<summary>First time here?</summary>

Nimbus works from issues and discussions, not drive-by PRs, so unapproved PRs from
outside the team are closed automatically. If that's you, open an
[issue](https://github.com/cloudflare/nimbus/issues/new/choose) (bug or fix proposal)
or a [discussion](https://github.com/cloudflare/nimbus/discussions) (feature) instead —
once a maintainer approves you there, your PRs stay open. See
[CONTRIBUTING.md](https://github.com/cloudflare/nimbus/blob/main/CONTRIBUTING.md).

</details>
