### PR TITLE
chore: pin only real section roots in overview-leaf sidebars

### DIFF
--- a/.changeset/pin-only-real-section-roots.md
+++ b/.changeset/pin-only-real-section-roots.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/nimbus-docs": patch
+---
+
+Fix overview-leaf reordering a flat top-level sidebar per page
+
+In `indexDisplay: "overview-leaf"` mode, the section-root pin relabelled and moved any top-level link whose slug matched the current section — including standalone top-level pages with no content beneath them. On a flat top-level of single pages, that pulled the current page to the front and renamed it "Overview" on every page. Pinning now requires the section to actually have content under it, so standalone pages stay put and keep their label.

--- a/packages/nimbus-docs/src/_internal/sidebar.ts
+++ b/packages/nimbus-docs/src/_internal/sidebar.ts
@@ -1384,6 +1384,15 @@ function pinSectionOverviewFirst(
     (it) => it.type === "link" && toRouteKey(it.href) === rootKey,
   );
   if (idx < 0) return items;
+  // Only pin a genuine section root — one the rail actually has content under.
+  // A standalone top-level page (its own slug equals `sectionSlug`, with nothing
+  // beneath it) is not a section landing; pinning and relabelling it "Overview"
+  // would reshuffle a flat top-level of standalone pages on every page and erase
+  // each page's real label. Require at least one other node under the section.
+  const hasSectionContent = flattenSidebar(items).some(
+    (l) => firstPathSegment(l.href) === sectionSlug && toRouteKey(l.href) !== rootKey,
+  );
+  if (!hasSectionContent) return items;
   const next = [...items];
   const [landing] = next.splice(idx, 1);
   if (!landing || landing.type !== "link") return items;

--- a/packages/nimbus-docs/test/sidebar-overview-leaf.test.ts
+++ b/packages/nimbus-docs/test/sidebar-overview-leaf.test.ts
@@ -147,6 +147,27 @@ test("pin: no section-root link → order unchanged", () => {
   );
 });
 
+test("pin: standalone top-level page is not pinned or relabelled (flat top-level stays stable)", () => {
+  // A flat top-level of standalone pages: viewing one makes its own slug the
+  // sectionSlug, but it has no content beneath it, so it must NOT be pulled to
+  // the front or renamed "Overview". Guards against per-page rail reordering.
+  const tree = [
+    link({ label: "Get started", href: "/get-started/", order: 0 }),
+    link({ label: "Installation", href: "/installation/", order: 1 }),
+    link({ label: "Philosophy", href: "/philosophy/", order: 2 }),
+  ];
+  const out = applyOverviewLeaf(tree, "installation", "Overview");
+  assert.deepEqual(
+    out.map((i) => [i.label, (i as any).href]),
+    [
+      ["Get started", "/get-started/"],
+      ["Installation", "/installation/"],
+      ["Philosophy", "/philosophy/"],
+    ],
+    "order preserved and no label rewritten to Overview",
+  );
+});
+
 test("custom overview label is honored for both lift and pin", () => {
   const tree = [
     link({ label: "DNS", href: "/dns/", order: 2 }),


### PR DESCRIPTION
## What & why

<!-- What this changes and why. Link the issue or discussion it came from. -->

## Checklist

- [ ] A maintainer approved this work (`lgtm+` on my issue or discussion), or I'm on the team
- [ ] Correct tier (framework / starter / registry) per the boundary test
- [ ] Edited `packages/nimbus-starter-source/`, not the `templates` branch
- [ ] Changeset added (`create-nimbus-docs` changeset if the starter changed)
- [ ] `pnpm typecheck`, `pnpm -r test`, and `pnpm templates:check` all green

<details>
<summary>First time here?</summary>

Nimbus works from issues and discussions, not drive-by PRs, so unapproved PRs from
outside the team are closed automatically. If that's you, open an
[issue](https://github.com/cloudflare/nimbus/issues/new/choose) (bug or fix proposal)
or a [discussion](https://github.com/cloudflare/nimbus/discussions) (feature) instead —
once a maintainer approves you there, your PRs stay open. See
[CONTRIBUTING.md](https://github.com/cloudflare/nimbus/blob/main/CONTRIBUTING.md).

</details>
