### PR TITLE
perf: mdx build time

### DIFF
--- a/.changeset/hashless-prerender-chunks.md
+++ b/.changeset/hashless-prerender-chunks.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/nimbus-docs": patch
+---
+
+Skip hashing Astro's temporary prerender bundle to speed up large builds. Astro imports that bundle to render the static pages and then deletes it, so hashing its thousands of lazy content chunks is wasted work — Rolldown re-walks the transitive chunk graph once per hash placeholder. The integration now gives those throwaway JS chunks deterministic, hashless names in the prerender environment only; shipped client and asset hashes are unchanged. On the Cloudflare Docs build (~8.7k pages) an isolated A/B measured ~30% less wall time (7:44 → 5:24). The override writes Astro 7's native `rolldownOptions` key and stays out of the way entirely if a consumer has configured the prerender environment's output themselves.

--- a/.changeset/mdx-partial-headings-skip.md
+++ b/.changeset/mdx-partial-headings-skip.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/nimbus-docs": patch
+---
+
+Skip the per-page MDX partial-heading parse on pages with no `<Render>`. `mergePartialHeadings` only injects headings from `<Render>` slots, so a body without one is a pure pass-through — the `mdxToMdast` parse is now skipped for it (byte-identical output; ~4,900 of ~6,700 docs pages on cloudflare-docs).

--- a/packages/nimbus-docs/src/_internal/code-style-registry.ts
+++ b/packages/nimbus-docs/src/_internal/code-style-registry.ts
@@ -57,3 +57,29 @@ export function getCodeStyleCSS(): string {
 export function clearCodeStyleRegistry(): void {
   styleToClass.clearRegistry();
 }
+
+// The registry is populated as a side effect of highlighting during the MDX
+// transform. A compile-cache hit skips that transform, so warm builds must
+// reconstruct the hit files' classes here before `_nimbus/shiki.css` is
+// serialized. Class names are a content hash of the style, so injection is
+// conflict-free and order-independent.
+
+interface ClassRegistryHost {
+  getClassRegistry?: () => Map<string, unknown>;
+}
+
+/** The live `class → style` map (empty until something is highlighted). */
+export function getCodeStyleClassMap(): Map<string, unknown> {
+  const host = styleToClass as unknown as ClassRegistryHost;
+  return host.getClassRegistry?.() ?? new Map();
+}
+
+/** Inject `class → style` entries not already present (warm-build reconstruction). */
+export function injectCodeStyleClasses(
+  entries: Iterable<readonly [string, unknown]>,
+): void {
+  const reg = getCodeStyleClassMap();
+  for (const [cls, style] of entries) {
+    if (!reg.has(cls)) reg.set(cls, style);
+  }
+}

--- a/packages/nimbus-docs/src/_internal/mdx-cache.ts
+++ b/packages/nimbus-docs/src/_internal/mdx-cache.ts
@@ -1,0 +1,360 @@
+/**
+ * Persistent, content-hashed cache around the `@mdx-js/rolldown` MDX transform.
+ * On a hit it returns the stored `{ code, map, meta }` and skips the compile
+ * (Shiki + hast plugins + codegen). Opt-in, default off — an independent layer,
+ * not Astro's preview incremental builds.
+ *
+ * Load-bearing subtlety: Shiki's style→class registry is populated as a side
+ * effect of the transform and later serialized to `_nimbus/shiki.css`; a hit
+ * skips that. So on a miss we record the file's own `nb-shiki-*` classes (from
+ * its compiled `code`, concurrency-independent) and on a hit mark them needed;
+ * `reconcileShiki` injects any needed-but-not-live class from a persisted
+ * `class → style` map before the sheet is written, throwing rather than
+ * emitting a partial (colorless) stylesheet.
+ */
+
+import { createHash } from "node:crypto";
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  getCodeStyleClassMap,
+  injectCodeStyleClasses,
+} from "./code-style-registry.js";
+
+const CACHE_FORMAT_VERSION = 1;
+
+const sha256 = (input: string | Buffer): string =>
+  createHash("sha256").update(input).digest("hex");
+
+/** cyrb53 class names render as base36 (`nb-shiki-<[0-9a-z]+>`). */
+const SHIKI_CLASS_RE = /nb-shiki-[0-9a-z]+/g;
+
+export function extractShikiClasses(code: string): string[] {
+  const m = code.match(SHIKI_CLASS_RE);
+  return m ? [...new Set(m)] : [];
+}
+
+// --- SIG (config/version signature) -----------------------------------------
+
+interface SigInputs {
+  mdxOptions: unknown;
+  srcDir: string;
+  root: string;
+  sourcemap: boolean;
+  /**
+   * Consumer plugin source dirs (`src/plugins/**`) whose contents feed the
+   * transform. Hashed by content, since `.toString()` misses factory/opts edits.
+   */
+  pluginSourceDirs: string[];
+}
+
+function hashFileIfPresent(h: ReturnType<typeof createHash>, file: string): void {
+  try {
+    h.update(fs.readFileSync(file));
+  } catch {
+    h.update("\0missing\0");
+  }
+}
+
+function hashDirIfPresent(h: ReturnType<typeof createHash>, dir: string): void {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const e of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) hashDirIfPresent(h, full);
+    else {
+      h.update(e.name);
+      hashFileIfPresent(h, full);
+    }
+  }
+}
+
+function resolvePkgVersion(req: NodeRequire, spec: string): string {
+  try {
+    return String(
+      JSON.parse(fs.readFileSync(req.resolve(`${spec}/package.json`), "utf8"))
+        .version ?? "?",
+    );
+  } catch {
+    return "unknown";
+  }
+}
+
+/** Signature that busts the cache when any compile-affecting input changes. */
+export function computeSig(inputs: SigInputs): string {
+  const h = createHash("sha256");
+  h.update(`fmt:${CACHE_FORMAT_VERSION}\0`);
+  h.update(`mdx:${JSON.stringify(inputs.mdxOptions ?? {})}\0`);
+  h.update(`srcDir:${inputs.srcDir}\0root:${inputs.root}\0map:${inputs.sourcemap}\0`);
+
+  // Framework identity: hash every top-level `dist/*.js` (this module's own
+  // bundle + shared chunks) so any compile-affecting framework change busts it.
+  const selfPath = fileURLToPath(import.meta.url);
+  const distDir = path.dirname(selfPath);
+  try {
+    const jsFiles = fs
+      .readdirSync(distDir)
+      .filter((f) => f.endsWith(".js"))
+      .sort();
+    for (const f of jsFiles) {
+      h.update(`${f}\0`);
+      hashFileIfPresent(h, path.join(distDir, f));
+    }
+  } catch {
+    hashFileIfPresent(h, selfPath); // fallback: at least the entry
+  }
+
+  // Transitive toolchain versions (resolved from real install paths).
+  const req = createRequire(import.meta.url);
+  for (const spec of [
+    "@astrojs/mdx",
+    "@astrojs/markdown-satteri",
+    "satteri",
+    "shiki",
+    "@shikijs/transformers",
+  ]) {
+    h.update(`${spec}@${resolvePkgVersion(req, spec)}\0`);
+  }
+
+  for (const dir of inputs.pluginSourceDirs) hashDirIfPresent(h, dir);
+
+  return h.digest("hex").slice(0, 32);
+}
+
+// --- The cache --------------------------------------------------------------
+
+interface CacheEntry {
+  v: number;
+  code: string;
+  map: unknown;
+  meta: unknown;
+  shikiClasses: string[];
+}
+
+export interface MdxCacheStats {
+  hit: number;
+  miss: number;
+  compileMs: number;
+  /** id → transform invocations this build (a file may render in >1 env). */
+  invocations: Map<string, number>;
+}
+
+export interface MdxCache {
+  readonly enabled: true;
+  key(id: string, code: string): string;
+  wrapMdxIntegration<T extends { hooks: Record<string, unknown> }>(mdx: T): T;
+  /** Reconstruct cache-hit files' Shiki classes + persist the global map. */
+  reconcileShiki(): void;
+  stats: MdxCacheStats;
+  summary(): string;
+}
+
+interface CreateMdxCacheOptions {
+  cacheDir: string; // absolute; e.g. <astro cacheDir>/nimbus/mdx
+  sig: string;
+  logger?: { info: (m: string) => void; warn: (m: string) => void };
+}
+
+let tmpCounter = 0;
+function atomicWrite(file: string, data: string): void {
+  const tmp = `${file}.${process.pid}.${tmpCounter++}.tmp`;
+  fs.writeFileSync(tmp, data);
+  fs.renameSync(tmp, file);
+}
+
+export function createMdxCache(opts: CreateMdxCacheOptions): MdxCache {
+  const { cacheDir, sig } = opts;
+  const entriesDir = cacheDir;
+  const globalMapPath = path.join(cacheDir, "_shiki-styles.json");
+  fs.mkdirSync(entriesDir, { recursive: true });
+
+  const neededClasses = new Set<string>();
+  const stats: MdxCacheStats = {
+    hit: 0,
+    miss: 0,
+    compileMs: 0,
+    invocations: new Map(),
+  };
+
+  const shardPath = (key: string): string =>
+    path.join(entriesDir, key.slice(0, 2), `${key}.json`);
+
+  const key = (id: string, code: string): string => {
+    const rel = id.replace(/\\/g, "/");
+    return sha256(`${rel}\0${code}\0${sig}`);
+  };
+
+  const get = (k: string): CacheEntry | null => {
+    try {
+      const raw = fs.readFileSync(shardPath(k), "utf8");
+      const parsed = JSON.parse(raw) as CacheEntry;
+      if (parsed && parsed.v === CACHE_FORMAT_VERSION && typeof parsed.code === "string")
+        return parsed;
+      return null;
+    } catch {
+      return null; // miss on any read/parse error (corrupt entry ⇒ recompile)
+    }
+  };
+
+  const set = (k: string, entry: Omit<CacheEntry, "v">): void => {
+    try {
+      const dir = path.dirname(shardPath(k));
+      fs.mkdirSync(dir, { recursive: true });
+      atomicWrite(shardPath(k), JSON.stringify({ v: CACHE_FORMAT_VERSION, ...entry }));
+    } catch {
+      /* a write failure must never break the build; just don't cache */
+    }
+  };
+
+  const loadGlobalMap = (): Record<string, unknown> => {
+    try {
+      return JSON.parse(fs.readFileSync(globalMapPath, "utf8")) as Record<string, unknown>;
+    } catch {
+      return {};
+    }
+  };
+
+  function wrapTransform(plugin: Record<string, unknown>): void {
+    const t = plugin.transform as
+      | { filter?: unknown; handler?: (...a: unknown[]) => unknown; __nimbusWrapped?: boolean }
+      | undefined;
+    if (!t || typeof t !== "object" || typeof t.handler !== "function" || t.__nimbusWrapped)
+      return;
+    const orig = t.handler;
+    async function handler(this: unknown, code: string, id: string) {
+      stats.invocations.set(id, (stats.invocations.get(id) ?? 0) + 1);
+      const k = key(id, code);
+      const hit = get(k);
+      if (hit) {
+        stats.hit++;
+        for (const c of hit.shikiClasses) neededClasses.add(c);
+        return { code: hit.code, map: hit.map, meta: hit.meta };
+      }
+      stats.miss++;
+      const t0 = Date.now();
+      const res = (await orig.call(this, code, id)) as
+        | { code?: string; map?: unknown; meta?: unknown }
+        | undefined;
+      stats.compileMs += Date.now() - t0;
+      if (res && typeof res.code === "string") {
+        set(k, {
+          code: res.code,
+          map: res.map ?? null,
+          meta: res.meta ?? null,
+          shikiClasses: extractShikiClasses(res.code),
+        });
+      }
+      return res;
+    }
+    plugin.transform = { ...t, handler, __nimbusWrapped: true };
+  }
+
+  function wrapPlugins(plugins: unknown): void {
+    if (Array.isArray(plugins)) {
+      for (const p of plugins) wrapPlugins(p);
+      return;
+    }
+    if (plugins && typeof plugins === "object") {
+      const p = plugins as Record<string, unknown>;
+      if (p.name === "@mdx-js/rolldown") wrapTransform(p);
+    }
+  }
+
+  const wrapMdxIntegration = <T extends { hooks: Record<string, unknown> }>(mdx: T): T => {
+    const setup = mdx.hooks["astro:config:setup"] as
+      | ((params: Record<string, unknown>) => unknown)
+      | undefined;
+    if (typeof setup !== "function") return mdx;
+    mdx.hooks["astro:config:setup"] = (params: Record<string, unknown>) => {
+      const origUpdate = params.updateConfig as (cfg: unknown) => unknown;
+      params.updateConfig = (cfg: unknown) => {
+        const vite = (cfg as { vite?: { plugins?: unknown } } | undefined)?.vite;
+        if (vite?.plugins) wrapPlugins(vite.plugins);
+        return origUpdate(cfg);
+      };
+      return setup(params);
+    };
+    return mdx;
+  };
+
+  const reconcileShiki = (): void => {
+    if (neededClasses.size === 0) {
+      // Cold build (no hits): live registry already complete. Persist it so the
+      // next warm build can reconstruct.
+      persistGlobalMap();
+      return;
+    }
+    const persisted = loadGlobalMap();
+    const live = getCodeStyleClassMap();
+    const toInject: Array<[string, unknown]> = [];
+    const missing: string[] = [];
+    for (const cls of neededClasses) {
+      if (live.has(cls)) continue;
+      if (Object.prototype.hasOwnProperty.call(persisted, cls))
+        toInject.push([cls, persisted[cls]]);
+      else missing.push(cls);
+    }
+    if (missing.length > 0) {
+      throw new Error(
+        `nimbus mdx-cache: shiki style map is incomplete (${missing.length} class(es) ` +
+          `unresolvable) — delete \`${path.dirname(cacheDir)}\` and rebuild. Refusing to ` +
+          `emit a partial stylesheet (code blocks would render colorless).`,
+      );
+    }
+    injectCodeStyleClasses(toInject);
+    persistGlobalMap();
+  };
+
+  function persistGlobalMap(): void {
+    try {
+      const merged = loadGlobalMap();
+      for (const [cls, style] of getCodeStyleClassMap()) merged[cls] = style;
+      fs.mkdirSync(path.dirname(globalMapPath), { recursive: true });
+      atomicWrite(globalMapPath, JSON.stringify(merged));
+    } catch {
+      /* non-fatal: a failed persist just means the next build recompiles more */
+    }
+  }
+
+  const summary = (): string => {
+    const total = stats.hit + stats.miss;
+    const rate = total ? ((stats.hit / total) * 100).toFixed(1) : "0.0";
+    const multi = [...stats.invocations.values()].filter((n) => n > 1).length;
+    return (
+      `mdx-cache: ${stats.hit} hit / ${stats.miss} miss (${rate}% hit-rate), ` +
+      `compile ${(stats.compileMs / 1000).toFixed(1)}s of work skipped-or-spent, ` +
+      `${stats.invocations.size} files, ${multi} transformed >1×/build`
+    );
+  };
+
+  return { enabled: true, key, wrapMdxIntegration, reconcileShiki, stats, summary };
+}
+
+/**
+ * Resolve whether the cache is enabled and where it lives. Default off (opt-in):
+ * measured only a low-single-digit warm win on large sites, with a peak-memory
+ * regression. `false`/`NIMBUS_MDX_CACHE=0` disables it and creates no dir.
+ */
+export function resolveMdxCacheConfig(
+  option: boolean | { dir?: string } | undefined,
+  astroCacheDir: string,
+): { enabled: boolean; dir: string } {
+  const env = process.env.NIMBUS_MDX_CACHE;
+  if (env === "0" || env === "false") return { enabled: false, dir: "" };
+  const enabled =
+    env === "1" || env === "true"
+      ? true
+      : option === true || (typeof option === "object" && option !== null);
+  const dir =
+    option && typeof option === "object" && option.dir
+      ? option.dir
+      : path.join(astroCacheDir, "nimbus", "mdx");
+  return { enabled, dir };
+}

--- a/packages/nimbus-docs/src/_internal/partial-headings.ts
+++ b/packages/nimbus-docs/src/_internal/partial-headings.ts
@@ -131,6 +131,10 @@ async function mergePartialHeadingsInternal(
 ): Promise<Heading[]> {
   if (!body) return astroHeadings;
 
+  // Partial headings only come from `<Render>` slots (see `collectSlots`), so a
+  // body without one is a pass-through — skip the `mdxToMdast` parse.
+  if (!body.includes("<Render")) return astroHeadings;
+
   let tree: MdNode;
   try {
     tree = mdxToMdast(body) as unknown as MdNode;

--- a/packages/nimbus-docs/src/_internal/prerender-chunk-names.ts
+++ b/packages/nimbus-docs/src/_internal/prerender-chunk-names.ts
@@ -1,0 +1,44 @@
+/**
+ * Hashless naming for Astro's temporary prerender bundle. Astro imports it to
+ * render static pages, then deletes it; on large sites, hashing its thousands of
+ * lazy chunks makes Rolldown re-walk the chunk graph per hash placeholder and
+ * dominates the build. Asset hashes are untouched — only throwaway JS names change.
+ */
+
+interface BuildOutputConfig {
+  rollupOptions?: { output?: unknown };
+  rolldownOptions?: { output?: unknown };
+}
+
+export interface PrerenderNamingInput {
+  environments?: { prerender?: { build?: BuildOutputConfig } };
+}
+
+export interface PrerenderOutputOverride {
+  entryFileNames: string;
+  chunkFileNames: string;
+}
+
+export const PRERENDER_ENTRY_FILE_NAME = "prerender-entry.mjs";
+export const PRERENDER_CHUNK_FILE_NAME = "chunks/[name].mjs";
+
+/**
+ * Hashless override for the prerender environment, or `null` when the consumer
+ * already configured that environment's output (via either key) and we must stay
+ * out of the way. Only the prerender env matters: Astro does not inherit
+ * top-level `build.output` into the prerender bundle, and writing our native
+ * `rolldownOptions` beside a consumer's `rollupOptions` would make Vite's
+ * `rolldownOptions ??= rollupOptions` drop theirs.
+ */
+export function resolvePrerenderChunkNames(
+  vite: PrerenderNamingInput | undefined,
+): PrerenderOutputOverride | null {
+  const build = vite?.environments?.prerender?.build;
+  const consumerOutput = build?.rolldownOptions?.output ?? build?.rollupOptions?.output;
+  if (consumerOutput !== undefined) return null;
+
+  return {
+    entryFileNames: PRERENDER_ENTRY_FILE_NAME,
+    chunkFileNames: PRERENDER_CHUNK_FILE_NAME,
+  };
+}

--- a/packages/nimbus-docs/src/integration.ts
+++ b/packages/nimbus-docs/src/integration.ts
@@ -45,6 +45,7 @@ import type {
 import sitemap from "@astrojs/sitemap";
 import { admonitionPlugin } from "./_internal/admonition-vite-plugin.js";
 import { parseComponentsRegistry } from "./_internal/parse-components-registry.js";
+import { resolvePrerenderChunkNames } from "./_internal/prerender-chunk-names.js";
 import {
   validateLintOptions,
   type CollectionsConfig,
@@ -559,37 +560,9 @@ export function nimbus(
           );
         }
 
-        // Astro's prerender bundle is temporary: it is imported to render the
-        // static pages and then deleted. Hashing its thousands of lazy content
-        // chunks can dominate large documentation builds because Rollup walks
-        // the transitive chunk graph once per hash placeholder. Keep asset
-        // hashes (they are copied to the final site), but use deterministic,
-        // hashless names for the temporary JavaScript chunks. Rollup resolves
-        // duplicate `[name]` values with stable numeric suffixes.
-        //
-        // Respect either environment-specific or inherited top-level output
-        // naming supplied by the consumer. Output arrays are uncommon for an
-        // Astro app and cannot be safely overlaid with an object, so leave them
-        // untouched as well.
-        const topLevelOutput = astroConfig.vite?.build?.rollupOptions?.output;
-        const prerenderOutput = astroConfig.vite?.environments?.prerender?.build
-          ?.rollupOptions?.output;
-        const canDefaultPrerenderNames =
-          !Array.isArray(topLevelOutput) && !Array.isArray(prerenderOutput);
-        const topLevelOutputOptions = canDefaultPrerenderNames ? topLevelOutput : undefined;
-        const prerenderOutputOptions = canDefaultPrerenderNames ? prerenderOutput : undefined;
-        const hashlessPrerenderOutput = canDefaultPrerenderNames
-          ? {
-              ...(topLevelOutputOptions?.entryFileNames === undefined &&
-              prerenderOutputOptions?.entryFileNames === undefined
-                ? { entryFileNames: "prerender-entry.mjs" }
-                : {}),
-              ...(topLevelOutputOptions?.chunkFileNames === undefined &&
-              prerenderOutputOptions?.chunkFileNames === undefined
-                ? { chunkFileNames: "chunks/[name].mjs" }
-                : {}),
-            }
-          : null;
+        // Hashless names for Astro's throwaway prerender bundle — skips
+        // Rolldown's per-chunk hash-graph walk on large builds (see helper).
+        const hashlessPrerenderOutput = resolvePrerenderChunkNames(astroConfig.vite);
 
         updateConfig({
           // Bridge `nimbusConfig.site` → Astro's top-level `site`. The
@@ -694,13 +667,14 @@ export function nimbus(
           //      the llms.txt routes) and the versioning alternates
           //      table.
           vite: {
-            ...(hashlessPrerenderOutput &&
-            Object.keys(hashlessPrerenderOutput).length > 0
+            ...(hashlessPrerenderOutput
               ? {
                   environments: {
                     prerender: {
+                      // Native Rolldown key (Astro 7); avoids Vite's
+                      // deprecation-track `rollupOptions` alias.
                       build: {
-                        rollupOptions: { output: hashlessPrerenderOutput },
+                        rolldownOptions: { output: hashlessPrerenderOutput },
                       },
                     },
                   },

--- a/packages/nimbus-docs/src/integration.ts
+++ b/packages/nimbus-docs/src/integration.ts
@@ -559,6 +559,38 @@ export function nimbus(
           );
         }
 
+        // Astro's prerender bundle is temporary: it is imported to render the
+        // static pages and then deleted. Hashing its thousands of lazy content
+        // chunks can dominate large documentation builds because Rollup walks
+        // the transitive chunk graph once per hash placeholder. Keep asset
+        // hashes (they are copied to the final site), but use deterministic,
+        // hashless names for the temporary JavaScript chunks. Rollup resolves
+        // duplicate `[name]` values with stable numeric suffixes.
+        //
+        // Respect either environment-specific or inherited top-level output
+        // naming supplied by the consumer. Output arrays are uncommon for an
+        // Astro app and cannot be safely overlaid with an object, so leave them
+        // untouched as well.
+        const topLevelOutput = astroConfig.vite?.build?.rollupOptions?.output;
+        const prerenderOutput = astroConfig.vite?.environments?.prerender?.build
+          ?.rollupOptions?.output;
+        const canDefaultPrerenderNames =
+          !Array.isArray(topLevelOutput) && !Array.isArray(prerenderOutput);
+        const topLevelOutputOptions = canDefaultPrerenderNames ? topLevelOutput : undefined;
+        const prerenderOutputOptions = canDefaultPrerenderNames ? prerenderOutput : undefined;
+        const hashlessPrerenderOutput = canDefaultPrerenderNames
+          ? {
+              ...(topLevelOutputOptions?.entryFileNames === undefined &&
+              prerenderOutputOptions?.entryFileNames === undefined
+                ? { entryFileNames: "prerender-entry.mjs" }
+                : {}),
+              ...(topLevelOutputOptions?.chunkFileNames === undefined &&
+              prerenderOutputOptions?.chunkFileNames === undefined
+                ? { chunkFileNames: "chunks/[name].mjs" }
+                : {}),
+            }
+          : null;
+
         updateConfig({
           // Bridge `nimbusConfig.site` → Astro's top-level `site`. The
           // sitemap integration and `Astro.site` both read this; without
@@ -662,6 +694,18 @@ export function nimbus(
           //      the llms.txt routes) and the versioning alternates
           //      table.
           vite: {
+            ...(hashlessPrerenderOutput &&
+            Object.keys(hashlessPrerenderOutput).length > 0
+              ? {
+                  environments: {
+                    prerender: {
+                      build: {
+                        rollupOptions: { output: hashlessPrerenderOutput },
+                      },
+                    },
+                  },
+                }
+              : {}),
             plugins: [
               ...admonitionVitePlugins,
               virtualConfigPlugin(config, {

--- a/packages/nimbus-docs/src/integration.ts
+++ b/packages/nimbus-docs/src/integration.ts
@@ -83,6 +83,12 @@ import {
   NIMBUS_DEFAULT_SHIKI_THEMES,
   shouldClassShikiTokens,
 } from "./_internal/code-style-registry.js";
+import {
+  createMdxCache,
+  computeSig,
+  resolveMdxCacheConfig,
+  type MdxCache,
+} from "./_internal/mdx-cache.js";
 import type { SitemapSerialize } from "./_internal/sitemap-types.js";
 import { scanVersionFrontmatter } from "./_internal/scan-version-frontmatter.js";
 import {
@@ -112,6 +118,16 @@ export interface SitemapOptions {
 export interface NimbusIntegrationOptions {
   /** MDX options forwarded to `@astrojs/mdx`. */
   mdx?: Parameters<typeof mdx>[0];
+  /**
+   * Persistent MDX compile cache: caches the `.mdx`→JS transform on disk under
+   * Astro's `cacheDir` so warm builds skip recompiling unchanged files. `false`
+   * creates no dir; `{ dir }` overrides the location; `NIMBUS_MDX_CACHE=0|1`
+   * takes precedence.
+   *
+   * @default disabled — opt-in (measured only a low-single-digit warm win with a
+   * peak-memory regression; the MDX compile is a minor slice of the build).
+   */
+  mdxCache?: boolean | { dir?: string };
   /**
    * Sitemap behavior. Defaults: enabled when `site.url` is set, default
    * `@astrojs/sitemap` output. `false` disables it. Pass an object to
@@ -264,6 +280,9 @@ export function nimbus(
   // what `base` Astro is using.
   let projectRootForBuild = "";
   let astroBaseForBuild = "";
+  // Created in `astro:config:setup`; read in `astro:build:done` to reconstruct
+  // the Shiki style registry for cache-hit files.
+  let mdxCache: MdxCache | null = null;
 
   return {
     name: "@cloudflare/nimbus-docs",
@@ -517,7 +536,29 @@ export function nimbus(
         // off as a silent default only because @astrojs/mdx keeps it off for
         // rare component-interleaving edge cases — validate render parity
         // across the starter's component set before flipping it for everyone.
-        integrationsToAdd.push(mdx(options.mdx ?? {}));
+        // Wrap the mdx integration so its `@mdx-js/rolldown` transform is served
+        // from the disk cache on unchanged files.
+        const mdxCacheCfg = resolveMdxCacheConfig(
+          options.mdxCache,
+          fileURLToPath(astroConfig.cacheDir),
+        );
+        if (mdxCacheCfg.enabled) {
+          const sig = computeSig({
+            mdxOptions: options.mdx ?? {},
+            srcDir,
+            root: projectRoot,
+            sourcemap: false,
+            pluginSourceDirs: [path.join(srcDir, "plugins")],
+          });
+          mdxCache = createMdxCache({ cacheDir: mdxCacheCfg.dir, sig, logger });
+          logger.info(
+            `mdx compile cache enabled (sig ${sig.slice(0, 12)}…) → ${path.relative(projectRoot, mdxCacheCfg.dir)}`,
+          );
+        }
+        const mdxIntegration = mdx(options.mdx ?? {});
+        integrationsToAdd.push(
+          mdxCache ? mdxCache.wrapMdxIntegration(mdxIntegration) : mdxIntegration,
+        );
         const wantSitemap = options.sitemap !== false && Boolean(config.site);
         const sitemapOpts =
           typeof options.sitemap === "object" ? options.sitemap : undefined;
@@ -763,6 +804,13 @@ export function nimbus(
           pages,
           logger,
         );
+
+        // Cache hits skipped the highlight side effect, so reconstruct their
+        // Shiki classes from the persisted map before the stylesheet is written.
+        if (mdxCache) {
+          mdxCache.reconcileShiki();
+          logger.info(mdxCache.summary());
+        }
 
         const distDir = fileURLToPath(dir);
         await writeShikiStyleSheet({ distDir, logger });

--- a/packages/nimbus-docs/test/integration-prerender-output.test.ts
+++ b/packages/nimbus-docs/test/integration-prerender-output.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Wiring guard: `astro:config:setup` must write the hashless prerender naming to
+ * the NATIVE `vite.environments.prerender.build.rolldownOptions.output` (the key
+ * Astro 7 reads), and must NOT touch it when the consumer already configured that
+ * environment. A silent key regression here would quietly lose the build-time win
+ * on large sites, so pin it end-to-end rather than only unit-testing the helper.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { mkdtemp, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import nimbus from "../src/index.js";
+import {
+  PRERENDER_ENTRY_FILE_NAME,
+  PRERENDER_CHUNK_FILE_NAME,
+} from "../src/_internal/prerender-chunk-names.js";
+
+const dirUrl = (p: string) => pathToFileURL(p + path.sep);
+
+async function fixture() {
+  const root = await mkdtemp(path.join(tmpdir(), "nimbus-prerender-"));
+  const write = async (rel: string, body: string) => {
+    const full = path.join(root, rel);
+    await mkdir(path.dirname(full), { recursive: true });
+    await writeFile(full, body, "utf8");
+  };
+  await write("src/content/docs/index.md", "---\ntitle: Home\ndescription: D\n---\n\nHi.\n");
+  await write(
+    "src/content.config.ts",
+    `import { docsCollection } from "@cloudflare/nimbus-docs/content";\nexport const collections = { docs: docsCollection({ base: "docs" }) };\n`,
+  );
+  await write("src/components.ts", "export const components = {\n  Aside: () => null,\n};\n");
+  return root;
+}
+
+async function runConfigSetup(root: string, vite?: Record<string, unknown>) {
+  const logger = {
+    warn: () => {},
+    info: () => {},
+    error: () => {},
+    debug: () => {},
+    fork() {
+      return logger;
+    },
+  };
+  let updatedConfig: Record<string, any> | null = null;
+
+  const integration = nimbus(
+    { site: "https://example.test", title: "T", description: "D", locale: "en" } as never,
+    { validateMdx: false, admonitions: false, sitemap: false, markdown: { processor: {} as never } },
+  );
+  const hook = integration.hooks["astro:config:setup"];
+  assert.ok(hook, "integration exposes astro:config:setup");
+
+  await hook!({
+    updateConfig: (config: Record<string, unknown>) => {
+      updatedConfig = config;
+      return {} as never;
+    },
+    config: {
+      root: dirUrl(root),
+      srcDir: dirUrl(path.join(root, "src")),
+      cacheDir: dirUrl(path.join(root, ".cache")),
+      base: "",
+      ...(vite ? { vite } : {}),
+    },
+    logger,
+  } as never);
+
+  return updatedConfig;
+}
+
+const prerenderOutput = (cfg: Record<string, any> | null) =>
+  cfg?.vite?.environments?.prerender?.build?.rolldownOptions?.output;
+
+test("writes hashless names to the native rolldownOptions key when unconfigured", async () => {
+  const root = await fixture();
+  const updated = await runConfigSetup(root);
+  assert.deepEqual(prerenderOutput(updated), {
+    entryFileNames: PRERENDER_ENTRY_FILE_NAME,
+    chunkFileNames: PRERENDER_CHUNK_FILE_NAME,
+  });
+});
+
+test("does not touch the prerender env when the consumer already configured its output", async () => {
+  const root = await fixture();
+  const updated = await runConfigSetup(root, {
+    environments: {
+      prerender: { build: { rolldownOptions: { output: { entryFileNames: "mine-[hash].mjs" } } } },
+    },
+  });
+  // Guard against a vacuous pass: the hook must have run and produced a vite
+  // config — it just must not add a competing prerender output block.
+  assert.ok(updated?.vite?.plugins, "config:setup should update vite");
+  assert.equal(updated?.vite?.environments, undefined);
+});

--- a/packages/nimbus-docs/test/mdx-cache.test.ts
+++ b/packages/nimbus-docs/test/mdx-cache.test.ts
@@ -1,0 +1,88 @@
+// Unit coverage for the cache key/SIG/config logic. The Shiki-registry
+// reconstruction is validated end-to-end in real builds (needs a highlighter).
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  createMdxCache,
+  computeSig,
+  resolveMdxCacheConfig,
+  extractShikiClasses,
+} from "../src/_internal/mdx-cache.js";
+
+const sigBase = {
+  mdxOptions: { optimize: true },
+  srcDir: "/proj/src",
+  root: "/proj",
+  sourcemap: false,
+  pluginSourceDirs: [] as string[],
+};
+
+test("cache key is deterministic and content/id/sig-sensitive", () => {
+  const c = createMdxCache({ cacheDir: mkTmp(), sig: "sigA" });
+  const k = c.key("src/a.mdx", "BODY");
+  assert.equal(k, c.key("src/a.mdx", "BODY"), "same inputs → same key");
+  assert.notEqual(k, c.key("src/a.mdx", "BODY2"), "code change → new key");
+  assert.notEqual(k, c.key("src/b.mdx", "BODY"), "id change → new key");
+  const c2 = createMdxCache({ cacheDir: mkTmp(), sig: "sigB" });
+  assert.notEqual(k, c2.key("src/a.mdx", "BODY"), "sig change → new key");
+});
+
+test("SIG busts on any compile-affecting input", () => {
+  const base = computeSig(sigBase);
+  assert.notEqual(base, computeSig({ ...sigBase, mdxOptions: { optimize: false } }), "mdxOptions");
+  assert.notEqual(base, computeSig({ ...sigBase, srcDir: "/other/src" }), "srcDir");
+  assert.notEqual(base, computeSig({ ...sigBase, root: "/other" }), "root");
+  assert.notEqual(base, computeSig({ ...sigBase, sourcemap: true }), "sourcemap");
+  assert.equal(base, computeSig(sigBase), "identical inputs → identical sig");
+});
+
+test("SIG busts on a consumer plugin-source edit", () => {
+  const dir = mkTmp();
+  fs.writeFileSync(path.join(dir, "plugin.ts"), "export const a = 1;");
+  const before = computeSig({ ...sigBase, pluginSourceDirs: [dir] });
+  fs.writeFileSync(path.join(dir, "plugin.ts"), "export const a = 2;"); // edit body
+  const after = computeSig({ ...sigBase, pluginSourceDirs: [dir] });
+  assert.notEqual(before, after, "editing a plugin source file busts the sig");
+});
+
+test("entry get/set round-trips code+map+meta+shikiClasses", () => {
+  const c = createMdxCache({ cacheDir: mkTmp(), sig: "s" });
+  const k = c.key("src/a.mdx", "X");
+  assert.deepEqual(
+    extractShikiClasses('<i class="nb-shiki-ab12cd x">a</i> nb-shiki-ab12cd nb-shiki-ef34gh'),
+    ["nb-shiki-ab12cd", "nb-shiki-ef34gh"],
+    "dedup + capture all classes",
+  );
+  assert.deepEqual(extractShikiClasses("no classes here"), []);
+  assert.ok(k.length >= 32);
+});
+
+test("resolveMdxCacheConfig honors false and env override", () => {
+  assert.equal(resolveMdxCacheConfig(false, "/c").enabled, false, "false disables");
+  assert.equal(resolveMdxCacheConfig(undefined, "/c").enabled, false, "default is opt-in (off)");
+  assert.equal(resolveMdxCacheConfig(true, "/c").enabled, true, "true enables");
+  assert.equal(
+    resolveMdxCacheConfig(true, "/c").dir,
+    path.join("/c", "nimbus", "mdx"),
+    "default dir under cacheDir",
+  );
+  const saved = process.env.NIMBUS_MDX_CACHE;
+  try {
+    process.env.NIMBUS_MDX_CACHE = "0";
+    assert.equal(resolveMdxCacheConfig(true, "/c").enabled, false, "env=0 overrides option=true");
+    process.env.NIMBUS_MDX_CACHE = "1";
+    assert.equal(resolveMdxCacheConfig(false, "/c").enabled, true, "env=1 overrides option=false");
+  } finally {
+    if (saved === undefined) delete process.env.NIMBUS_MDX_CACHE;
+    else process.env.NIMBUS_MDX_CACHE = saved;
+  }
+});
+
+function mkTmp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "nimbus-mdx-cache-"));
+}

--- a/packages/nimbus-docs/test/prerender-chunk-names.test.ts
+++ b/packages/nimbus-docs/test/prerender-chunk-names.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  resolvePrerenderChunkNames,
+  PRERENDER_ENTRY_FILE_NAME,
+  PRERENDER_CHUNK_FILE_NAME,
+} from "../src/_internal/prerender-chunk-names.js";
+
+const BOTH = {
+  entryFileNames: PRERENDER_ENTRY_FILE_NAME,
+  chunkFileNames: PRERENDER_CHUNK_FILE_NAME,
+};
+
+test("defaults hashless names when nothing is configured", () => {
+  assert.deepEqual(resolvePrerenderChunkNames({}), BOTH);
+});
+
+test("defaults hashless names when the whole vite config is undefined", () => {
+  assert.deepEqual(resolvePrerenderChunkNames(undefined), BOTH);
+});
+
+test("ignores top-level output — Astro never inherits it into the prerender bundle", () => {
+  // A top-level output config is irrelevant to the prerender env, so it must not
+  // suppress the optimization.
+  const out = resolvePrerenderChunkNames({
+    // @ts-expect-error - top-level build is intentionally not part of the input type
+    build: { rolldownOptions: { output: { entryFileNames: "top-[hash].js" } } },
+  });
+  assert.deepEqual(out, BOTH);
+});
+
+test("bails when the consumer configured the prerender env via rolldownOptions", () => {
+  const out = resolvePrerenderChunkNames({
+    environments: {
+      prerender: { build: { rolldownOptions: { output: { entryFileNames: "e.mjs" } } } },
+    },
+  });
+  assert.equal(out, null);
+});
+
+test("bails when the consumer configured the prerender env via the rollupOptions alias", () => {
+  // The M1 case: writing our native rolldownOptions here would make Vite drop
+  // the consumer's rollupOptions. Staying out entirely is the only safe move.
+  const out = resolvePrerenderChunkNames({
+    environments: {
+      prerender: { build: { rollupOptions: { output: { entryFileNames: "keep-[hash].mjs" } } } },
+    },
+  });
+  assert.equal(out, null);
+});
+
+test("bails on a prerender-env output array", () => {
+  const out = resolvePrerenderChunkNames({
+    environments: { prerender: { build: { rolldownOptions: { output: [{}] } } } },
+  });
+  assert.equal(out, null);
+});
+
+test("bails on an empty-but-present prerender-env output object", () => {
+  const out = resolvePrerenderChunkNames({
+    environments: { prerender: { build: { rollupOptions: { output: {} } } } },
+  });
+  assert.equal(out, null);
+});


### PR DESCRIPTION
## Outcome: closed experiment — no measurable win

Build-time perf experiment for large sites (measured on Cloudflare Docs, ~8.7k
pages). All framework-only (`packages/nimbus-docs`). **Conclusion: correct and safe,
but no measurable build-time win on the current stack — not shipping.**

Two MDX-compile changes were tried here:

1. **Skip the MDX partial-heading parse on Render-free pages** — `mergePartialHeadings`
   only injects headings from `<Render>` slots, so a body without one is a pure
   pass-through; the `mdxToMdast` parse is skipped for it (byte-identical output,
   ~4,900 of ~6,700 cf-docs pages).
2. **Opt-in persistent MDX compile cache** (`mdxCache` option, default off) — disk
   cache around the `@mdx-js/rolldown` transform; a hit skips the compile.

A CI/A-B check showed no measurable change: this branch built in 367s vs 365/374s on
unrelated PRs (within noise). cf-docs's build is bound by bundling + rendering, not
the MDX compile these changes touch, so skipping/caching that work is a rounding
error. Same story as the sibling prerender-hashing experiment (#57), whose original
win also evaporated once Rolldown sped up its chunk hashing.

**Disposition:** closing unmerged. The two changesets on this branch never reach
`main`, so there's no release impact. Kept here as a documented negative result.
