### PR TITLE
fix: base-prefix NimbusHead SEO URLs for sub-path deployments

### DIFF
--- a/.changeset/base-aware-head-urls.md
+++ b/.changeset/base-aware-head-urls.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/nimbus-docs": patch
+---
+
+Fix `NimbusHead` emitting base-less SEO URLs on sub-path deployments (e.g. `base: '/docs'`).
+
+`new URL(path, Astro.site)` resolves against the origin only and drops the configured `base`, so the `rel=sitemap` link, the LLM-index `rel=alternate`, `og:image`/`twitter:image`, the JSON-LD `isPartOf.url`, the versioned `canonical`, and the cross-version `rel=alternate` all pointed at the origin root and 404'd under a sub-path. Every internal path handed to `new URL(..., Astro.site)` is now `base`-prefixed via a `withBase` helper, matching the existing `BASE_URL` handling for the favicon and Shiki stylesheet.
+
+Root deployments (`base: '/'`) are unaffected: the helper is a no-op when no base is configured, and already-based paths pass through unchanged (idempotent).

--- a/.changeset/bright-maps-visit.md
+++ b/.changeset/bright-maps-visit.md
@@ -8,4 +8,4 @@ Verified the generated starter with optimization on and with `mdx: { optimize: f
 
 Spot-checked the starter `components` page, which includes JSX tags in prose, inline code with `<...>`, quoted code, and package names. The optimized and opt-out renders preserve those special-character text probes and match structurally.
 
-Temporarily cap the supported Astro peer range to `>=7.0.0 <7.1.0` while the Astro 7.1.x static build regression is upstream.
+Constrain the supported Astro peer range to `>=7.0.0 <7.1.0 || >=7.2.0 <8.0.0`: the 7.1.x line is excluded while its static-build regression is open upstream, but 7.2.x is admitted (verified against a sub-path build). Generated templates and the dev pin stay on the verified 7.0.x line.

--- a/packages/nimbus-docs/package.json
+++ b/packages/nimbus-docs/package.json
@@ -78,7 +78,7 @@
 		"prepack": "tsdown"
 	},
 	"peerDependencies": {
-		"astro": ">=7.0.0 <7.1.0",
+		"astro": ">=7.0.0 <7.1.0 || >=7.2.0 <8.0.0",
 		"react": ">=19.0.0",
 		"react-dom": ">=19.0.0"
 	},

--- a/packages/nimbus-docs/src/components/NimbusHead.astro
+++ b/packages/nimbus-docs/src/components/NimbusHead.astro
@@ -83,6 +83,20 @@ const {
 
 const hasSite = !!Astro.site;
 
+// Prefix a site-root-relative path with the configured `base` so generated
+// asset links resolve under sub-path deployments (e.g. `/docs`). `new URL(p,
+// Astro.site)` resolves against the origin only and drops `base`, so any
+// internal path handed to it must be based first. External/absolute URLs and
+// already-based paths pass through unchanged.
+const baseUrl = import.meta.env.BASE_URL;
+const withBase = (path: string): string => {
+  if (/^([a-z][a-z0-9+.\-]*:|\/\/)/i.test(path)) return path;
+  const b = baseUrl.replace(/\/$/, "");
+  if (!b) return path;
+  const p = path.startsWith("/") ? path : `/${path}`;
+  return p === b || p.startsWith(`${b}/`) ? p : `${b}${p}`;
+};
+
 // Cross-version alternates and canonical override. When the page is part
 // of a versioned-docs class with a current-version sibling that isn't
 // `self`, `record.canonical` points to it — we emit that URL as the
@@ -122,12 +136,12 @@ const llmsIndexPath =
       : "/llms.txt";
 const llmsIndexUrl =
   llmsIndexPath && Astro.site
-    ? new URL(llmsIndexPath, Astro.site).href
+    ? new URL(withBase(llmsIndexPath), Astro.site).href
     : llmsIndexPath;
 
 const canonical = Astro.site
   ? versionCanonicalPath
-    ? new URL(versionCanonicalPath, Astro.site).href
+    ? new URL(withBase(versionCanonicalPath), Astro.site).href
     : new URL(Astro.url.pathname, Astro.site).href
   : null;
 
@@ -169,7 +183,7 @@ const defaultSocialImage = existsSync(userOpenGraphImage)
 const socialImagePath = socialImage ?? config.socialImage ?? defaultSocialImage;
 const ogImage = socialImagePath
   ? Astro.site
-    ? new URL(socialImagePath, Astro.site).href
+    ? new URL(withBase(socialImagePath), Astro.site).href
     : socialImagePath
   : null;
 const ogImageAlt = config.socialImageAlt;
@@ -189,7 +203,7 @@ const structuredData = canonical
             isPartOf: {
               "@type": "WebSite",
               name: config.title,
-              url: Astro.site ? new URL("/", Astro.site).href : config.site,
+              url: Astro.site ? new URL(withBase("/"), Astro.site).href : config.site,
             },
             ...(lastUpdated ? { dateModified: lastUpdated.toISOString() } : {}),
           }),
@@ -211,7 +225,7 @@ const shikiCssHref = `${import.meta.env.BASE_URL}_nimbus/shiki.css${import.meta.
 <link rel="icon" type={faviconType} href={faviconHref} />
 <link rel="stylesheet" href={shikiCssHref} />
 {hasSite && canonical && <link rel="canonical" href={canonical} />}
-{hasSite && <link rel="sitemap" href="/sitemap-index.xml" />}
+{hasSite && <link rel="sitemap" href={withBase("/sitemap-index.xml")} />}
 {markdownUrl && !isHiddenVersion && (
   <link rel="alternate" type="text/markdown" href={markdownUrl} />
 )}
@@ -227,7 +241,7 @@ const shikiCssHref = `${import.meta.env.BASE_URL}_nimbus/shiki.css${import.meta.
   <link
     rel="alternate"
     data-version={alt.version}
-    href={Astro.site ? new URL(alt.url, Astro.site).href : alt.url}
+    href={Astro.site ? new URL(withBase(alt.url), Astro.site).href : alt.url}
   />
 ))}
 


### PR DESCRIPTION
## What

`NimbusHead` emitted base-less SEO URLs on sub-path deployments (e.g. `base: '/docs'`). `new URL(path, Astro.site)` resolves against the origin only and drops the configured `base`, so several head URLs pointed at the origin root and 404'd under a sub-path.

Every internal path **NimbusHead itself** hands to `new URL(..., Astro.site)` is now `base`-prefixed via a `withBase` helper, matching the existing `BASE_URL` handling for the favicon and Shiki stylesheet. Fixed:

- `rel=sitemap` link
- `canonical` (including the versioned canonical override)
- `og:image` / `twitter:image`
- JSON-LD `isPartOf.url`
- the LLM-index (`/llms.txt`) `rel=alternate` head link
- cross-version `rel=alternate` links

## Also in this PR — widen the Astro peer range

`peerDependencies.astro` was capped at `>=7.0.0 <7.1.0` to dodge the open 7.1.x static-build regression. This admits **7.2.x** as well — `>=7.0.0 <7.1.0 || >=7.2.0 <8.0.0` — so consumers on the current Astro line resolve cleanly, while still excluding the broken 7.1.x. The `bright-maps-visit` changeset note is reconciled to describe the final range. Generated templates and the dev pin stay on the verified 7.0.x line.

## Why

Documentation sites served under a sub-path had broken canonical / OG / sitemap URLs — an SEO and social-card regression, plus a hard 404 for the sitemap. And a sub-path site on the current Astro (7.2.x) couldn't take this fix without a peer-range conflict.

## Scope — not covered here

This fixes only the URLs NimbusHead constructs itself. The per-page **markdown** `rel=alternate` (`markdownUrl`) is passed in already-absolute by callers, so `withBase` can't repair it; the same base-drop affects the `.md` links inside `llms.txt` and the `Source:` line in `.md` bodies. That's a separate, systemic caller-side issue tracked in #78.

## Notes

- Root deployments (`base: '/'`) are unaffected: the helper is a no-op when no base is configured, and already-based paths pass through unchanged (idempotent).
- Includes a patch changeset for the head-URL fix; the peer-range change rides in the existing `bright-maps-visit` (minor) note.