### PR TITLE
fix: shiki dev css base match

### DIFF
--- a/.changeset/shiki-dev-css-base-match.md
+++ b/.changeset/shiki-dev-css-base-match.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/nimbus-docs": patch
+---
+
+Fix syntax-highlighted code rendering uncoloured in dev on sites with a non-root `base` (e.g. `base: "/docs"`). The dev middleware that serves `_nimbus/shiki.css` compared the request path exactly against the based asset path, but Vite strips `base` from `req.url` at a non-root base, so the request 404'd and tokens fell back to their inherited colour. It now matches by suffix, serving the stylesheet regardless of how Vite presents `base`. Production was unaffected — the stylesheet is written statically at build time.

--- a/packages/nimbus-docs/src/integration.ts
+++ b/packages/nimbus-docs/src/integration.ts
@@ -692,7 +692,8 @@ export function nimbus(
         clearCodeStyleRegistry();
         server.middlewares.use((req, res, next) => {
           const pathname = new URL(req.url ?? "/", "http://nimbus.local").pathname;
-          if (pathname !== assetPathWithBase(astroBaseForBuild, "_nimbus/shiki.css")) {
+          // Vite strips `base` from req.url at a non-root base; match by suffix.
+          if (!pathname.endsWith("/_nimbus/shiki.css")) {
             next();
             return;
           }
@@ -851,11 +852,6 @@ function canonicalizePathname(pathname: string): string {
   if (!s.startsWith("/")) s = `/${s}`;
   if (s.length > 1 && s.endsWith("/")) s = s.slice(0, -1);
   return s;
-}
-
-function assetPathWithBase(base: string, assetPath: string): string {
-  const cleanBase = base && base !== "/" ? `/${base.replace(/^\/+|\/+$/g, "")}` : "";
-  return `${cleanBase}/${assetPath.replace(/^\/+/, "")}`;
 }
 
 function normalizeShikiCSS(currentCSS: string): string {


### PR DESCRIPTION
## What & why

<!-- What this changes and why. Link the issue or discussion it came from. -->

## Checklist

- [ ] A maintainer approved this work (`lgtm+` on my issue or discussion), or I'm on the team
- [ ] Correct tier (framework / starter / registry) per the boundary test
- [ ] Edited `packages/nimbus-starter-source/`, not the `templates` branch
- [ ] Changeset added (`create-nimbus-docs` changeset if the starter changed)
- [ ] `pnpm typecheck`, `pnpm -r test`, and `pnpm templates:check` all green

<details>
<summary>First time here?</summary>

Nimbus works from issues and discussions, not drive-by PRs, so unapproved PRs from
outside the team are closed automatically. If that's you, open an
[issue](https://github.com/cloudflare/nimbus/issues/new/choose) (bug or fix proposal)
or a [discussion](https://github.com/cloudflare/nimbus/discussions) (feature) instead —
once a maintainer approves you there, your PRs stay open. See
[CONTRIBUTING.md](https://github.com/cloudflare/nimbus/blob/main/CONTRIBUTING.md).

</details>
