### PR TITLE
fix: replace deprecated optimizeDeps.esbuildOptions with rolldownOptions

### DIFF
--- a/packages/nimbus-docs/src/integration.ts
+++ b/packages/nimbus-docs/src/integration.ts
@@ -712,10 +712,12 @@ export function nimbus(
               },
             ],
             optimizeDeps: {
-              esbuildOptions: {
-                alias: {
-                  "css-tree": "css-tree/dist/csstree.esm",
-                  csso: "csso/dist/csso.esm",
+              rolldownOptions: {
+                resolve: {
+                  alias: {
+                    "css-tree": "css-tree/dist/csstree.esm",
+                    csso: "csso/dist/csso.esm",
+                  },
                 },
               },
             },


### PR DESCRIPTION
## Summary

PR #76 added the `css-tree`/`csso` alias using `optimizeDeps.esbuildOptions`. Vite 8 (Rolldown) deprecates this option in favor of `optimizeDeps.rolldownOptions`, producing warnings:

```
[WARN] [vite] You or a plugin you are using have set `optimizeDeps.esbuildOptions` but this option is now deprecated. Vite now uses Rolldown to optimize the dependencies. Please use `optimizeDeps.rolldownOptions` instead.
```

## Changes

- Move the `css-tree`/`csso` alias from `optimizeDeps.esbuildOptions.alias` to `optimizeDeps.rolldownOptions.resolve.alias` (the Rolldown-native equivalent)

## Verification

- `pnpm run build` — passes
- `pnpm run typecheck` — passes