### PR TITLE
feat: add cacheKey to getStaticPaths helpers for incremental build support

### DIFF
--- a/.changeset/incremental-build-cacheKey.md
+++ b/.changeset/incremental-build-cacheKey.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/nimbus-docs": minor
+---
+
+`getDocsStaticPaths` and `getCollectionStaticPaths` now include a `cacheKey` (derived from the entry's `digest`) on each returned path. This enables Astro's experimental incremental build cache to skip re-rendering unchanged pages. No-op when `experimental.incrementalBuild` is not enabled in `astro.config.ts`.

--- a/packages/nimbus-docs/src/index.ts
+++ b/packages/nimbus-docs/src/index.ts
@@ -907,6 +907,11 @@ import type { AstroGlobal, GetStaticPaths } from "astro";
  * filtered in production. Each path passes `{ entry }` as props so the
  * page component can access it via `getDocsPageProps(Astro)`.
  *
+ * A `cacheKey` derived from the entry's `digest` is included on each path
+ * so Astro's experimental incremental build cache can skip re-rendering
+ * unchanged pages. This is a no-op when `experimental.incrementalBuild` is
+ * not enabled in `astro.config.ts`.
+ *
  * Usage:
  *
  *   // src/pages/[...slug].astro
@@ -926,6 +931,7 @@ export const getDocsStaticPaths: GetStaticPaths = async () => {
   return entries.map((entry) => ({
     params: { slug: entry.id },
     props: { entry },
+    cacheKey: String(entry.digest),
   }));
 };
 
@@ -1015,6 +1021,11 @@ export async function getRouteFlags(entry: {
  * filtered in production (same rule as `getDocsStaticPaths`). Each path
  * passes `{ entry }` as props for `getCollectionPageProps()`.
  *
+ * A `cacheKey` derived from the entry's `digest` is included on each path
+ * so Astro's experimental incremental build cache can skip re-rendering
+ * unchanged pages. This is a no-op when `experimental.incrementalBuild` is
+ * not enabled in `astro.config.ts`.
+ *
  * Usage:
  *
  *   // src/pages/api/[...slug].astro
@@ -1032,6 +1043,7 @@ export function getCollectionStaticPaths(collection: string): GetStaticPaths {
     return entries.map((entry) => ({
       params: { slug: entry.id },
       props: { entry },
+      cacheKey: String(entry.digest),
     }));
   };
 }

--- a/packages/nimbus-docs/src/types/virtual-modules.d.ts
+++ b/packages/nimbus-docs/src/types/virtual-modules.d.ts
@@ -40,6 +40,7 @@ declare module "astro:content" {
     collection: C;
     data: Record<string, unknown>;
     body?: string;
+    digest?: number | string;
   }
 
   export interface SchemaContext {


### PR DESCRIPTION
## Problem

Astro's experimental incremental build cache (`experimental.incrementalBuild`) requires a `cacheKey` on each path returned by `getStaticPaths` to decide whether a page can be skipped. Without it, every page is re-rendered on every build even when the content hasn't changed.

## Fix

Add `cacheKey: String(entry.digest)` to the return values of:

- `getDocsStaticPaths` — primary docs collection catch-all route
- `getCollectionStaticPaths` — non-primary collection catch-all routes

`entry.digest` is Astro's content hash — it changes when the entry's source file changes, which is exactly the signal the incremental cache needs.

## Safety

This is a **no-op** when `experimental.incrementalBuild` is not enabled in `astro.config.ts`. The `cacheKey` property is just extra data on the returned path object; Astro only reads it when the incremental cache is active (`cache` is non-null). Existing users see zero behavior change.

Also added `digest?: number | string` to the `CollectionEntry` stub in `virtual-modules.d.ts` so the package typechecks in isolation.