### PR TITLE
fix: highlight CLI placeholders in code blocks

### DIFF
--- a/apps/www/src/styles/globals.css
+++ b/apps/www/src/styles/globals.css
@@ -536,6 +536,12 @@ pre.astro-code .highlighted-word {
 	box-shadow: 0 0 0 1px color-mix(in oklch, var(--nb-info) 30%, transparent);
 }
 
+/* CLI placeholders such as <BUCKET_NAME>. */
+pre.astro-code .nb-cli-placeholder,
+pre.astro-code .nb-cli-placeholder span {
+        color: var(--nb-info) !important;
+}
+
 /* ---- Mobile sidebar toggle ---- */
 
 /* Hide hamburger on pages without a sidebar dialog. */

--- a/packages/nimbus-docs/src/_internal/code-transformers.ts
+++ b/packages/nimbus-docs/src/_internal/code-transformers.ts
@@ -231,7 +231,33 @@ const META_SYMBOL = Symbol("nimbus-meta");
 interface MetaCarrier {
   [META_SYMBOL]?: NimbusMeta;
 }
+function cliPlaceholderTransformer(): ShikiTransformer {
+  return {
+    name: "nimbus:cli-placeholder",
 
+  preprocess(code, options) {
+    const placeholderPattern = /<[A-Z][A-Z0-9_]*>/g;
+    const matches = [...code.matchAll(placeholderPattern)];
+
+    if (matches.length === 0) return;
+
+    options.decorations ||= [];
+
+    for (const match of matches) {
+        const start = match.index;
+        if (start === undefined) continue;
+
+        options.decorations.push({
+          start,
+          end: start + match[0].length,
+          properties: {
+            class: "nb-cli-placeholder",
+          },
+        });
+      }
+    },
+  };
+}
 /**
  * The canonical Shiki transformer chain for Nimbus. Returns a fresh
  * array each call so callers don't accidentally mutate a shared list.
@@ -247,15 +273,16 @@ export function defaultCodeTransformers(
 ): ShikiTransformer[] {
   const beforeTitle = options.beforeTitleTransformers ?? [];
   return [
-    transformerNotationDiff(),
-    transformerNotationHighlight(),
-    transformerNotationFocus(),
-    transformerNotationErrorLevel(),
-    transformerNotationWordHighlight(),
-    nimbusMetaTransformer(),
-    ...beforeTitle,
-    ...(options.classTokens ? [getCodeStyleTransformer()] : []),
-    titleAndLangTransformer(),
+  transformerNotationDiff(),
+  transformerNotationHighlight(),
+  transformerNotationFocus(),
+  transformerNotationErrorLevel(),
+  transformerNotationWordHighlight(),
+  cliPlaceholderTransformer(),
+  nimbusMetaTransformer(),
+  ...beforeTitle,
+  ...(options.classTokens ? [getCodeStyleTransformer()] : []),
+  titleAndLangTransformer(),
   ];
 }
 
@@ -279,7 +306,7 @@ export function nimbusMetaTransformer(): ShikiTransformer {
 
     // Quoted search words are applied as decorations over the raw source.
     // Decorations split tokens cleanly on the hast.
-    preprocess(code, options) {
+      preprocess(code, options) {
       if (!this.options.meta?.__raw) return;
       const meta = getMeta(this);
       if (meta.searchWords.length === 0) return;

--- a/packages/nimbus-starter-source/src/content/docs/components.mdx
+++ b/packages/nimbus-starter-source/src/content/docs/components.mdx
@@ -194,6 +194,11 @@ function Counter() {
 }
 ```
 
+### CLI placeholder test
+
+```sh
+npx wrangler r2 bucket sippy enable <BUCKET_NAME>
+
 ## Partials
 
 Reuse a chunk of MDX across pages with `<Render>`. Partials live in


### PR DESCRIPTION
## What & why

Fixes #32496.

CLI placeholders such as `<BUCKET_NAME>` were not highlighted correctly in code blocks.

This adds a Shiki transformer that detects CLI-style placeholders and applies the existing Nimbus info styling to them.

MohamedH1998 confirmed that I could take this issue and is happy to review the PR.

## Checklist

- [ ] A maintainer approved this work (`lgtm+`) on the issue/discussion
- [ ] Correct tier (framework / starter / registry) per the boundary test
- [x] Edited `packages/nimbus-starter-source/`, not the `templates` branch
- [ ] Changeset added (if required)
- [ ] `pnpm typecheck`, `pnpm -r test`, and `pnpm templates:check` all green