### PR TITLE
Bump nanoid to 3.3.18 via pnpm override for GHSA-2v37-7h3g-55p8

### DIFF
--- a/.changeset/nanoid-3.3.18.md
+++ b/.changeset/nanoid-3.3.18.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/nimbus-docs": patch
+---
+
+Bump `nanoid` to 3.3.18 to resolve GHSA-2v37-7h3g-55p8 (CVE-2026-67213): custom generators can loop indefinitely when size is zero.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3975,13 +3975,8 @@ packages:
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -9013,9 +9008,7 @@ snapshots:
 
   muggle-string@0.4.1: {}
 
-  nanoid@3.3.16: {}
-
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -9185,13 +9178,13 @@ snapshots:
 
   postcss@8.5.19:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,3 +10,7 @@ packages:
   # framework's lockfile. Excluding them here keeps `pnpm install` from
   # injecting their importers into pnpm-lock.yaml.
   - "!examples/local"
+
+# nanoid@3.3.18 patches GHSA-2v37-7h3g-55p8; postcss ^3.3.17 won't resolve to it
+overrides:
+  nanoid: 3.3.18


### PR DESCRIPTION
Fixes the CI audit failure on the changeset release PR (#87).

## Advisory

[GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) / CVE-2026-67213 — nanoid custom generators can loop indefinitely when size is zero (high).

## Dependency chain

```
packages/nimbus-docs > @astrojs/mdx > astro > vite > postcss > nanoid@3.3.17
```

## Why an override

postcss 8.5.26 (latest) still declares `nanoid@^3.3.17`, so lockfiles can resolve to the vulnerable 3.3.17. Upstream merged a lockfile bump ([postcss#2124](https://github.com/postcss/postcss/pull/2124)) but never tightened the range. Attempts to move to nanoid 5.x ([#2130](https://github.com/postcss/postcss/pull/2130)) or inline it ([#2062](https://github.com/postcss/postcss/pull/2062)) were abandoned.

A pnpm override is the cleanest fix — no fake direct dependency, minimal lockfile diff.