### PR TITLE
fix: add nimbus-docs as a runtime dep

### DIFF
--- a/.changeset/fix-create-runtime-dependency.md
+++ b/.changeset/fix-create-runtime-dependency.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/create-nimbus-docs": patch
+---
+
+Install `@cloudflare/nimbus-docs` as a runtime dependency so the CLI can load its adapter helpers.

--- a/packages/create-nimbus-docs/package.json
+++ b/packages/create-nimbus-docs/package.json
@@ -44,12 +44,12 @@
   },
   "dependencies": {
     "@clack/prompts": "^0.9.1",
+    "@cloudflare/nimbus-docs": "workspace:*",
     "giget": "^3.3.0",
     "mri": "^1.2.0",
     "typescript": "^5.8.3"
   },
   "devDependencies": {
-    "@cloudflare/nimbus-docs": "workspace:*",
     "@types/mri": "^1.1.4",
     "@types/node": "^20.17.0",
     "tsdown": "^0.20.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       '@clack/prompts':
         specifier: ^0.9.1
         version: 0.9.1
+      '@cloudflare/nimbus-docs':
+        specifier: workspace:*
+        version: link:../nimbus-docs
       giget:
         specifier: ^3.3.0
         version: 3.3.0
@@ -133,9 +136,6 @@ importers:
         specifier: ^5.8.3
         version: 5.9.3
     devDependencies:
-      '@cloudflare/nimbus-docs':
-        specifier: workspace:*
-        version: link:../nimbus-docs
       '@types/mri':
         specifier: ^1.1.4
         version: 1.2.0

--- a/scripts/audit-published-prod.mjs
+++ b/scripts/audit-published-prod.mjs
@@ -3,6 +3,7 @@
 import { spawnSync } from "node:child_process";
 
 const BLOCKING_SEVERITIES = new Set(["high", "critical"]);
+const AUDIT_TIMEOUT_MS = 60_000;
 const PUBLISHED_IMPORTERS = new Set([
   "packages/nimbus-docs",
   "packages/create-nimbus-docs",
@@ -10,11 +11,25 @@ const PUBLISHED_IMPORTERS = new Set([
 
 const ALLOWLIST = new Map([]);
 
-const result = spawnSync("pnpm", ["audit", "--prod", "--json"], {
-  encoding: "utf8",
-});
+const result = spawnSync(
+  "pnpm",
+  [
+    "--config.registry=https://registry.npmjs.org/",
+    "--config.@cloudflare:registry=https://registry.npmjs.org/",
+    "audit",
+    "--prod",
+    "--json",
+  ],
+  { encoding: "utf8", timeout: AUDIT_TIMEOUT_MS },
+);
 
 if (result.error) {
+  if (result.error.code === "ETIMEDOUT") {
+    console.error(
+      `pnpm audit timed out after ${AUDIT_TIMEOUT_MS / 1000}s. The npm audit service may be unavailable.`,
+    );
+    process.exit(1);
+  }
   console.error(`Failed to run pnpm audit: ${result.error.message}`);
   process.exit(1);
 }
@@ -32,6 +47,13 @@ try {
   process.exit(1);
 }
 
+if (isPlainObject(report?.error)) {
+  console.error(
+    `pnpm audit failed: ${String(report.error.summary ?? report.error.message ?? "unknown registry error")}`,
+  );
+  process.exit(1);
+}
+
 const advisories = report?.advisories;
 if (!isPlainObject(advisories)) {
   if (isPlainObject(report?.vulnerabilities)) {
@@ -40,7 +62,7 @@ if (!isPlainObject(advisories)) {
     );
   } else {
     console.error(
-      "Unexpected pnpm audit JSON: missing advisories object and vulnerabilities object.",
+      `Unexpected pnpm audit JSON: missing advisories object and vulnerabilities object (keys: ${Object.keys(report ?? {}).join(", ") || "none"}).`,
     );
   }
   process.exit(1);


### PR DESCRIPTION
## What & why

<!-- What this changes and why. Link the issue or discussion it came from. -->

## Checklist

- [ ] A maintainer approved this work (`lgtm+` on my issue or discussion), or I'm on the team
- [ ] Correct tier (framework / starter / registry) per the boundary test
- [ ] Edited `packages/nimbus-starter-source/`, not the `templates` branch
- [ ] Changeset added (`create-nimbus-docs` changeset if the starter changed)
- [ ] `pnpm typecheck`, `pnpm -r test`, and `pnpm templates:check` all green

<details>
<summary>First time here?</summary>

Nimbus works from issues and discussions, not drive-by PRs, so unapproved PRs from
outside the team are closed automatically. If that's you, open an
[issue](https://github.com/cloudflare/nimbus/issues/new/choose) (bug or fix proposal)
or a [discussion](https://github.com/cloudflare/nimbus/discussions) (feature) instead —
once a maintainer approves you there, your PRs stay open. See
[CONTRIBUTING.md](https://github.com/cloudflare/nimbus/blob/main/CONTRIBUTING.md).

</details>
