### PR TITLE
Preserve static page route casing

### DIFF
--- a/.changeset/preserve-static-route-case.md
+++ b/.changeset/preserve-static-route-case.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/nimbus-docs": patch
+---
+
+Preserve casing in static page routes during duplicate-route checks.

--- a/packages/nimbus-docs/src/lint/site-model.ts
+++ b/packages/nimbus-docs/src/lint/site-model.ts
@@ -202,8 +202,8 @@ export function formatShadowedRoutes(dups: DuplicateGroup[]): string {
  * framework's docs renderer collides with a content entry the *content*
  * enumeration also catches.
  *
- * URL normalization: lowercase each segment + strip a trailing `/index`,
- * matching Astro's `joinSegments` behavior for static routes. Underscore-
+ * URL normalization: preserve each static segment's casing and strip a trailing
+ * `/index`, matching Astro's `joinSegments` behavior for static routes. Underscore-
  * prefixed files are skipped (Astro's private-helper convention). Endpoint
  * files (`name.<ext>.<ts|js>`) map to `/name.<ext>` per Astro's convention.
  */
@@ -258,7 +258,7 @@ function isDynamicSegment(seg: string): boolean {
  *
  *   pages/index.astro       → /
  *   pages/search.astro      → /search
- *   pages/Search.astro      → /search       (Astro lowercases via joinSegments)
+ *   pages/Search.astro      → /Search       (Astro preserves static segment casing)
  *   pages/llms.txt.ts       → /llms.txt     (endpoint: strip .ts, keep .txt)
  *   pages/blog/index.astro  → /blog
  *   pages/blog/post.md      → /blog/post
@@ -277,8 +277,7 @@ function fileToRoute(parts: string[], ext: string): string {
   // Strip trailing `index` segment so `foo/index.astro` → `/foo`.
   if (cloned[cloned.length - 1] === "index") cloned.pop();
 
-  // Lowercase each segment to match Astro's `joinSegments` behavior.
-  const joined = cloned.map((s) => s.toLowerCase()).join("/");
+  const joined = cloned.join("/");
   return joined === "" ? "/" : `/${joined}`;
 }
 

--- a/packages/nimbus-docs/test/lint/site-model.test.ts
+++ b/packages/nimbus-docs/test/lint/site-model.test.ts
@@ -333,7 +333,7 @@ test("enumerateStaticPageRoutes skips underscore-prefixed files and directories"
   );
 });
 
-test("enumerateStaticPageRoutes lowercases segments to match Astro's joinSegments", () => {
+test("enumerateStaticPageRoutes preserves static segment casing to match Astro", () => {
   withTempPages(
     {
       "Search.astro": "x",
@@ -342,7 +342,7 @@ test("enumerateStaticPageRoutes lowercases segments to match Astro's joinSegment
     (pagesRoot, projectRoot) => {
       const routes = enumerateStaticPageRoutes(pagesRoot, projectRoot);
       const urls = routes.map((r) => r.url).sort();
-      assert.deepEqual(urls, ["/blog/my-post", "/search"]);
+      assert.deepEqual(urls, ["/Blog/My-Post", "/Search"]);
     },
   );
 });


### PR DESCRIPTION
## Summary

Nimbus was lowercasing static page names during duplicate-route checks, even though Astro keeps their casing. `src/pages/Guide.astro` was therefore checked as `/guide` while Astro serves `/Guide`.

This preserves the static segments as written, updates the regression test, and adds the patch changeset.

Closes #100

## Checks

- `node --import tsx --test test/lint/site-model.test.ts`
- `pnpm --filter nimbus-docs typecheck`
- `pnpm --filter nimbus-docs build`