### PR TITLE
Reject registry writes through linked paths

### DIFF
--- a/.changeset/harden-registry-symlink-containment.md
+++ b/.changeset/harden-registry-symlink-containment.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/nimbus-docs": patch
+---
+
+Reject registry install paths that resolve outside src through symbolic links.

--- a/packages/nimbus-docs/src/cli/component.ts
+++ b/packages/nimbus-docs/src/cli/component.ts
@@ -13,6 +13,7 @@ import { spawn } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
+  realpathSync,
   readFileSync,
   writeFileSync,
 } from "node:fs";
@@ -191,7 +192,41 @@ export function assertInsideSrc(
     );
   }
 
+  assertResolvedInsideSrc(srcDir, targetAbs, filePath, itemName);
+
   return targetAbs;
+}
+
+function assertResolvedInsideSrc(
+  srcDir: string,
+  targetAbs: string,
+  filePath: string,
+  itemName: string,
+): void {
+  // A new `src/` directory cannot contain a link yet. Once it exists, resolve
+  // the nearest existing target ancestor so writes cannot follow a link outside it.
+  if (!existsSync(srcDir)) return;
+
+  const realSrcDir = realpathSync(srcDir);
+  let existing = targetAbs;
+  while (!existsSync(existing)) {
+    const parent = dirname(existing);
+    if (parent === existing) return;
+    existing = parent;
+  }
+
+  const realExisting = realpathSync(existing);
+  const pathFromSrc = relative(realSrcDir, realExisting);
+  if (
+    pathFromSrc === ".." ||
+    pathFromSrc.startsWith(`..${sep}`) ||
+    isAbsolute(pathFromSrc)
+  ) {
+    throw new Error(
+      `Refusing to install "${itemName}": registry file path "${filePath}" ` +
+        "resolves outside the project's src/ directory through a symbolic link.",
+    );
+  }
 }
 
 /**

--- a/packages/nimbus-docs/test/registry-path-containment.test.ts
+++ b/packages/nimbus-docs/test/registry-path-containment.test.ts
@@ -4,7 +4,7 @@
 
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync, symlinkSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -63,6 +63,32 @@ test("absolute path is rejected before any write", async () => {
       /is absolute/,
     );
     assert.equal(existsSync(abs), false);
+  });
+});
+
+test("a linked parent cannot redirect a registry write outside src", async () => {
+  await withProject(async (cwd, srcDir) => {
+    const outside = await mkdtemp(path.join(tmpdir(), "nimbus-outside-"));
+    try {
+      const link = path.join(srcDir, "components/ui/link");
+      mkdirSync(path.dirname(link), { recursive: true });
+      symlinkSync(
+        outside,
+        link,
+        process.platform === "win32" ? "junction" : "dir",
+      );
+
+      await assert.rejects(
+        installComponents(
+          [item([{ path: "components/ui/link/escaped.txt", content: "x" }])],
+          { cwd, yes: true, overwrite: false },
+        ),
+        /resolves outside the project's src\/ directory/,
+      );
+      assert.equal(existsSync(path.join(outside, "escaped.txt")), false);
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

The component installer checked the lexical destination under `src`, but a junction or symlink in an existing parent directory could redirect the write elsewhere.

This resolves the nearest existing target ancestor before writing and rejects it when it falls outside the resolved `src` directory. The regression test covers a Windows junction and a POSIX directory symlink.

Closes #101

## Checks

- `node --import tsx --test --test-name-pattern "linked parent" test/registry-path-containment.test.ts`
- `pnpm --filter nimbus-docs typecheck`
- `pnpm --filter nimbus-docs build`