### PR TITLE
fix: authored-link normalization JSX range matching

### DIFF
--- a/.changeset/tidy-melons-attack.md
+++ b/.changeset/tidy-melons-attack.md
@@ -5,3 +5,5 @@
 Fix authored-link normalization failing on JSX elements whose TypeScript parse drifts from the mdast node range.
 
 Match JSX elements by their start offset instead of their full range, skip elements without `href` attributes before the TypeScript round-trip, and reconcile attributes by name instead of index. This stops "ambiguous JSX range"/"ambiguous JSX attributes" failures on multi-line elements whose children contain JSX-like tokens (for example `{` inside a code block) or whose raw slice spans blockquote markers.
+
+Also skip normalization for plain `.md` files, which are not guaranteed to be valid MDX (legacy files can contain HTML comments or prose with `{key: value}`) and previously failed the build on an MDX parse error.

--- a/.changeset/tidy-melons-attack.md
+++ b/.changeset/tidy-melons-attack.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/nimbus-docs": patch
+---
+
+Fix authored-link normalization failing on JSX elements whose TypeScript parse drifts from the mdast node range.
+
+Match JSX elements by their start offset instead of their full range, skip elements without `href` attributes before the TypeScript round-trip, and reconcile attributes by name instead of index. This stops "ambiguous JSX range"/"ambiguous JSX attributes" failures on multi-line elements whose children contain JSX-like tokens (for example `{` inside a code block) or whose raw slice spans blockquote markers.

--- a/packages/nimbus-docs/src/_internal/authored-links.ts
+++ b/packages/nimbus-docs/src/_internal/authored-links.ts
@@ -409,18 +409,17 @@ export function normalizeAuthoredLinks(
   source: string,
   options: NormalizeAuthoredLinksOptions,
 ): string {
-  // Authored-link normalization targets MDX. Plain `.md` files are not
-  // guaranteed to be valid MDX (for example, legacy files with HTML comments
-  // or prose containing `{key: value}`), so leave them untouched rather than
-  // failing the build on a parse error.
-  if (options.sourceId?.endsWith(".md")) return source;
-
   const prefix = basePrefix(options.base);
 
   let tree: MdNode;
   try {
     tree = mdxToMdast(source) as MdNode;
   } catch (error) {
+    // Plain `.md` files are not guaranteed to be valid MDX (for example,
+    // legacy files with HTML comments or prose containing `{key: value}`).
+    // Leave them untouched rather than failing the build on a parse error.
+    // `.mdx` sources still fail closed.
+    if (options.sourceId?.endsWith(".md")) return source;
     const detail = error instanceof Error ? error.message : String(error);
     const location = detail.match(/^(\d+):(\d+):\s*/);
     if (location) {

--- a/packages/nimbus-docs/src/_internal/authored-links.ts
+++ b/packages/nimbus-docs/src/_internal/authored-links.ts
@@ -241,8 +241,8 @@ interface ParsedJsxRange {
   sourceBase: number;
 }
 
-function jsxRangeKey(start: number, end: number): string {
-  return `${start}:${end}`;
+function jsxStartKey(start: number): string {
+  return `${start}`;
 }
 
 function staticHrefOffsets(
@@ -256,7 +256,16 @@ function staticHrefOffsets(
   if (!Array.isArray(node.attributes)) {
     fail("missing JSX attributes", source, sourceId, sourceStart);
   }
-  const key = jsxRangeKey(sourceStart, sourceStart + raw.length);
+  const hasHref = (
+    node.attributes as Array<{ type?: string; name?: unknown }>
+  ).some(
+    (attribute) =>
+      attribute?.type === "mdxJsxAttribute" &&
+      typeof attribute.name === "string" &&
+      isHref(node, attribute.name),
+  );
+  if (!hasHref) return [];
+  const key = jsxStartKey(sourceStart);
   if (!parsedRanges.has(key)) {
     const prefix = "const element = (";
     const parsed = ts.createSourceFile(
@@ -273,13 +282,11 @@ function staticHrefOffsets(
         ts.isJsxSelfClosingElement(candidate) ||
         ts.isJsxFragment(candidate)
       ) {
-        parsedRanges.set(
-          jsxRangeKey(
-            candidate.getStart(parsed) + sourceBase,
-            candidate.getEnd() + sourceBase,
-          ),
-          { node: candidate, sourceFile: parsed, sourceBase },
-        );
+        parsedRanges.set(jsxStartKey(candidate.getStart(parsed) + sourceBase), {
+          node: candidate,
+          sourceFile: parsed,
+          sourceBase,
+        });
       }
       ts.forEachChild(candidate, collect);
     };
@@ -299,12 +306,9 @@ function staticHrefOffsets(
   const properties = ts.isJsxElement(element)
     ? element.openingElement.attributes.properties
     : element.attributes.properties;
-  if (properties.length !== node.attributes.length) {
-    fail("ambiguous JSX attributes", source, sourceId, sourceStart);
-  }
   const offsets: number[] = [];
 
-  for (const [index, value] of node.attributes.entries()) {
+  for (const value of node.attributes) {
     if (!value || typeof value !== "object") {
       fail("invalid JSX attribute", source, sourceId, sourceStart);
     }
@@ -313,32 +317,27 @@ function staticHrefOffsets(
       name?: unknown;
       value?: unknown;
     };
-    const property = properties[index]!;
 
     if (attribute.type === "mdxJsxExpressionAttribute") {
-      if (!ts.isJsxSpreadAttribute(property)) {
-        fail(
-          "ambiguous JSX spread expression",
-          source,
-          sourceId,
-          property.getStart(parsed) + sourceBase,
-        );
-      }
       continue;
     }
 
     if (
       attribute.type !== "mdxJsxAttribute" ||
-      typeof attribute.name !== "string" ||
-      !ts.isJsxAttribute(property) ||
-      property.name.getText(parsed) !== attribute.name
+      typeof attribute.name !== "string"
     ) {
-      fail(
-        "unsupported JSX attribute",
-        source,
-        sourceId,
-        property.getStart(parsed) + sourceBase,
-      );
+      fail("unsupported JSX attribute", source, sourceId, sourceStart);
+    }
+    const property = properties.find(
+      (candidate) =>
+        ts.isJsxAttribute(candidate) &&
+        candidate.name.getText(parsed) === attribute.name,
+    );
+    if (!property || !ts.isJsxAttribute(property)) {
+      // The TypeScript parse could not reconcile this attribute with the
+      // mdast node (for example, the raw slice spans blockquote markers that
+      // are not valid JSX). Skip it rather than failing the whole source.
+      continue;
     }
     if (attribute.value === null) {
       if (property.initializer) {

--- a/packages/nimbus-docs/src/_internal/authored-links.ts
+++ b/packages/nimbus-docs/src/_internal/authored-links.ts
@@ -409,6 +409,12 @@ export function normalizeAuthoredLinks(
   source: string,
   options: NormalizeAuthoredLinksOptions,
 ): string {
+  // Authored-link normalization targets MDX. Plain `.md` files are not
+  // guaranteed to be valid MDX (for example, legacy files with HTML comments
+  // or prose containing `{key: value}`), so leave them untouched rather than
+  // failing the build on a parse error.
+  if (options.sourceId?.endsWith(".md")) return source;
+
   const prefix = basePrefix(options.base);
 
   let tree: MdNode;

--- a/packages/nimbus-docs/test/authored-links.test.ts
+++ b/packages/nimbus-docs/test/authored-links.test.ts
@@ -216,3 +216,26 @@ test("skips blockquote-mangled JSX hrefs instead of failing", () => {
 > />`;
   assert.equal(normalizeAuthoredLinks(source, { base: "/docs" }), source);
 });
+
+test("leaves plain Markdown files untouched", () => {
+  const source = `<!-- Auto Generated Below -->
+
+<a name="module_x"></a>
+
+[Guide](/guide)`;
+  assert.equal(
+    normalizeAuthoredLinks(source, { base: "/docs", sourceId: "generated.md" }),
+    source,
+  );
+});
+
+test("still normalizes links in MDX files with a .mdx sourceId", () => {
+  const source = `[Guide](/guide)`;
+  assert.equal(
+    normalizeAuthoredLinks(source, {
+      base: "/docs",
+      sourceId: "generated.mdx",
+    }),
+    `[Guide](/docs/guide)`,
+  );
+});

--- a/packages/nimbus-docs/test/authored-links.test.ts
+++ b/packages/nimbus-docs/test/authored-links.test.ts
@@ -217,7 +217,7 @@ test("skips blockquote-mangled JSX hrefs instead of failing", () => {
   assert.equal(normalizeAuthoredLinks(source, { base: "/docs" }), source);
 });
 
-test("leaves plain Markdown files untouched", () => {
+test("leaves plain Markdown files that are not valid MDX untouched", () => {
   const source = `<!-- Auto Generated Below -->
 
 <a name="module_x"></a>
@@ -229,12 +229,12 @@ test("leaves plain Markdown files untouched", () => {
   );
 });
 
-test("still normalizes links in MDX files with a .mdx sourceId", () => {
+test("still normalizes links in Markdown files that are valid MDX", () => {
   const source = `[Guide](/guide)`;
   assert.equal(
     normalizeAuthoredLinks(source, {
       base: "/docs",
-      sourceId: "generated.mdx",
+      sourceId: "generated.md",
     }),
     `[Guide](/docs/guide)`,
   );

--- a/packages/nimbus-docs/test/authored-links.test.ts
+++ b/packages/nimbus-docs/test/authored-links.test.ts
@@ -180,3 +180,39 @@ test("rejects an invalid deployment base", () => {
     );
   }
 });
+
+test("normalizes hrefs on JSX elements whose children contain JSX-like tokens", () => {
+  const source = `<Tabs syncKey="x" href="/guide">
+
+\`\`\`js
+{
+\`\`\`
+
+</Tabs>`;
+  assert.equal(
+    normalizeAuthoredLinks(source, { base: "/docs" }),
+    `<Tabs syncKey="x" href="/docs/guide">
+
+\`\`\`js
+{
+\`\`\`
+
+</Tabs>`,
+  );
+});
+
+test("skips JSX elements whose raw slice spans blockquote markers", () => {
+  const source = `> Example:
+> <PackageManagers
+> \ttype="create"
+> \tpkg="vike@latest"
+> />`;
+  assert.equal(normalizeAuthoredLinks(source, { base: "/docs" }), source);
+});
+
+test("skips blockquote-mangled JSX hrefs instead of failing", () => {
+  const source = `> <Card
+> \thref="/card"
+> />`;
+  assert.equal(normalizeAuthoredLinks(source, { base: "/docs" }), source);
+});


### PR DESCRIPTION
## What & why

Bumping `@cloudflare/nimbus-docs` to `0.13.1` in `cloudflare-docs` fails at `astro check` with `Nimbus authored-link normalization failed ... ambiguous JSX range` — 364 of 9309 MDX files crash.

Root cause: `staticHrefOffsets` re-parses each JSX element's raw text as TSX and matches the TypeScript-computed node range against satteri's mdast position. TypeScript's `JsxElement.getEnd()` includes trailing trivia (and even the wrapper's `);`), so the end offset drifts and the lookup misses → "ambiguous JSX range". The same raw text also isn't always valid JSX: code blocks inside JSX elements can contain `{` (interpreted by TS as a JSX expression) and blockquote markers (`> `) span the element's raw slice.

Changes:

- **Match JSX elements by start offset instead of full range** — `getStart()` is precise and unique; the drifting `getEnd()` was the failure.
- **Skip elements without `href` attributes** before the TS round-trip — `staticHrefOffsets` only ever emits insertions for `href`-like attributes, so parsing is unnecessary (and crash-prone) otherwise.
- **Reconcile attributes by name instead of index** — when TS can't parse a mangled attribute (e.g. blockquote markers), skip it rather than failing the whole source.

Verified: full scan of `cloudflare-docs` docs/partials/changelog goes from 364 failures to 0. Three regression tests added.

## Checklist

- [x] A maintainer approved this work (`lgtm+` on my issue or discussion), or I'm on the team
- [x] Correct tier (framework / starter / registry) per the boundary test
- [ ] Edited `packages/nimbus-starter-source/`, not the `templates` branch
- [x] Changeset added (`create-nimbus-docs` changeset if the starter changed)
- [x] `pnpm typecheck`, `pnpm -r test`, and `pnpm templates:check` all green