### PR TITLE
chore: update previews to use pr head

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -40,6 +40,8 @@ jobs:
       id-token: write # pkg.pr.new authenticates the publish via GitHub OIDC (no npm token, no secret)
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
@@ -86,14 +88,15 @@ jobs:
       #     unauthenticated URLs and does not support private repos — same
       #     public-flip prerequisite the npm release already depends on.
       - name: Publish preview
-        run: >-
-          pnpm exec pkg-pr-new publish
-          --pnpm
-          --compact
-          --no-template
-          --packageManager=pnpm
-          ./packages/nimbus-docs
-          ./packages/create-nimbus-docs
+        run: |
+          PREVIEW_SHA="$(git rev-parse HEAD)"
+          NIMBUS_PREVIEW_REF="${PREVIEW_SHA:0:7}" pnpm exec pkg-pr-new publish \
+            --pnpm \
+            --compact \
+            --no-template \
+            --packageManager=pnpm \
+            ./packages/nimbus-docs \
+            ./packages/create-nimbus-docs
         env:
           NIMBUS_PREVIEW: "1"
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/packages/create-nimbus-docs/scripts/repin-preview.mjs
+++ b/packages/create-nimbus-docs/scripts/repin-preview.mjs
@@ -8,9 +8,8 @@ const DEP_FIELDS = ["dependencies", "devDependencies", "peerDependencies"];
 const NIMBUS_DOCS = "@cloudflare/nimbus-docs";
 // Coupled to preview-release.yml's `pkg-pr-new publish --compact` URL shape.
 
-export function repinPreview(templatesDir, pr) {
-  const normalizedPr = validatePr(pr);
-  const previewUrl = `https://pkg.pr.new/${NIMBUS_DOCS}@${normalizedPr}`;
+export function repinPreview(templatesDir, ref) {
+  const previewUrl = `https://pkg.pr.new/${NIMBUS_DOCS}@${validatePreviewRef(ref)}`;
 
   for (const entry of readdirSync(templatesDir, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue;
@@ -33,19 +32,19 @@ export function repinPreview(templatesDir, pr) {
   }
 }
 
-function validatePr(pr) {
-  const value = String(pr ?? "");
-  if (!/^[1-9]\d*$/.test(value)) {
-    throw new Error("PR number must be a positive integer.");
+function validatePreviewRef(ref) {
+  const value = String(ref ?? "");
+  if (!/^[0-9a-f]{7}$/.test(value)) {
+    throw new Error("Preview ref must be a 7-character Git commit.");
   }
   return value;
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   try {
-    const [templatesDir, pr] = process.argv.slice(2);
-    if (!templatesDir) throw new Error("Usage: repin-preview.mjs <templatesDir> <pr>");
-    repinPreview(templatesDir, pr);
+    const [templatesDir, ref] = process.argv.slice(2);
+    if (!templatesDir) throw new Error("Usage: repin-preview.mjs <templatesDir> <preview-ref>");
+    repinPreview(templatesDir, ref);
   } catch (err) {
     console.error(err instanceof Error ? err.message : String(err));
     process.exit(1);

--- a/packages/create-nimbus-docs/test/repin-preview.test.ts
+++ b/packages/create-nimbus-docs/test/repin-preview.test.ts
@@ -6,7 +6,7 @@ import { test } from "node:test";
 
 import { repinPreview } from "../scripts/repin-preview.mjs";
 
-const PREVIEW_URL = "https://pkg.pr.new/@cloudflare/nimbus-docs@42";
+const PREVIEW_URL = "https://pkg.pr.new/@cloudflare/nimbus-docs@9283890";
 
 function makeTemplates() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "nimbus-repin-"));
@@ -35,7 +35,7 @@ function readPackage(root: string, variant: string) {
 test("repinPreview rewrites generated variants to the compact pkg.pr.new URL", () => {
   const root = makeTemplates();
   try {
-    repinPreview(root, "42");
+    repinPreview(root, "9283890");
     assert.equal(readPackage(root, "template").dependencies["@cloudflare/nimbus-docs"], PREVIEW_URL);
     assert.equal(
       readPackage(root, "template-empty").dependencies["@cloudflare/nimbus-docs"],
@@ -46,15 +46,16 @@ test("repinPreview rewrites generated variants to the compact pkg.pr.new URL", (
   }
 });
 
-test("repinPreview is idempotent and validates PR numbers", () => {
+test("repinPreview is idempotent and validates preview refs", () => {
   const root = makeTemplates();
   try {
-    repinPreview(root, "42");
+    repinPreview(root, "abcdef0");
     const once = fs.readFileSync(path.join(root, "template", "package.json"), "utf8");
-    repinPreview(root, "42");
+    repinPreview(root, "abcdef0");
     const twice = fs.readFileSync(path.join(root, "template", "package.json"), "utf8");
     assert.equal(twice, once);
-    assert.throws(() => repinPreview(root, "not-a-pr"), /positive integer/);
+    assert.throws(() => repinPreview(root, "129"), /7-character Git commit/);
+    assert.throws(() => repinPreview(root, "9283890b"), /7-character Git commit/);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
@@ -69,7 +70,7 @@ test("repinPreview fails when a variant is missing nimbus-docs", () => {
     );
 
     assert.throws(
-      () => repinPreview(root, "42"),
+      () => repinPreview(root, "abcdef0"),
       /template-empty\/package\.json does not depend on @cloudflare\/nimbus-docs/,
     );
   } finally {

--- a/packages/create-nimbus-docs/tsdown.config.ts
+++ b/packages/create-nimbus-docs/tsdown.config.ts
@@ -10,12 +10,20 @@ const pkg = JSON.parse(
 const minNodeVersion = pkg.engines?.node?.replace(/^>=/, "") ?? "20.0.0";
 const isPreview = process.env.NIMBUS_PREVIEW === "1";
 const previewPr = process.env.PR_NUMBER ?? null;
+const previewRef = process.env.NIMBUS_PREVIEW_REF ?? null;
 
 function requirePreviewPr(): string {
   if (!previewPr || !/^[1-9]\d*$/.test(previewPr)) {
     throw new Error("NIMBUS_PREVIEW=1 requires a positive integer PR_NUMBER.");
   }
   return previewPr;
+}
+
+function requirePreviewRef(): string {
+  if (!previewRef || !/^[0-9a-f]{7}$/.test(previewRef)) {
+    throw new Error("NIMBUS_PREVIEW=1 requires a 7-character Git commit in NIMBUS_PREVIEW_REF.");
+  }
+  return previewRef;
 }
 
 export default defineConfig({
@@ -40,7 +48,8 @@ export default defineConfig({
     async "build:done"(ctx) {
       if (!isPreview) return;
 
-      const pr = requirePreviewPr();
+      requirePreviewPr();
+      const ref = requirePreviewRef();
       const templatesDir = resolve(ctx.options.outDir, "templates");
       const [{ generateTemplates }, { repinPreview }] = await Promise.all([
         import("./scripts/copy-template.mjs"),
@@ -48,7 +57,7 @@ export default defineConfig({
       ]);
 
       generateTemplates(templatesDir);
-      repinPreview(templatesDir, pr);
+      repinPreview(templatesDir, ref);
     },
   },
 });


### PR DESCRIPTION
## What & why

<!-- What this changes and why. Link the issue or discussion it came from. -->

## Checklist

- [ ] A maintainer approved this work (`lgtm+` on my issue or discussion), or I'm on the team
- [ ] Correct tier (framework / starter / registry) per the boundary test
- [ ] Edited `packages/nimbus-starter-source/`, not the `templates` branch
- [ ] Changeset added (`create-nimbus-docs` changeset if the starter changed)
- [ ] `pnpm typecheck`, `pnpm -r test`, and `pnpm templates:check` all green

<details>
<summary>First time here?</summary>

Nimbus works from issues and discussions, not drive-by PRs, so unapproved PRs from
outside the team are closed automatically. If that's you, open an
[issue](https://github.com/cloudflare/nimbus/issues/new/choose) (bug or fix proposal)
or a [discussion](https://github.com/cloudflare/nimbus/discussions) (feature) instead —
once a maintainer approves you there, your PRs stay open. See
[CONTRIBUTING.md](https://github.com/cloudflare/nimbus/blob/main/CONTRIBUTING.md).

</details>
