### PR TITLE
fix: preserve authored Markdown across rendering pipelines

### DIFF
--- a/.changeset/preserve-authored-links.md
+++ b/.changeset/preserve-authored-links.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/nimbus-docs": patch
+---
+
+Preserve authored root-relative links and unrelated source across Markdown and
+MDX, including HTML containers, fenced examples, Unicode, and CRLF. Keep plain
+Markdown unchanged when generating Markdown and agent endpoint output.

--- a/.github/workflows/templates.yml
+++ b/.github/workflows/templates.yml
@@ -11,6 +11,7 @@ on:
       - "packages/create-nimbus-docs/**"
       - "packages/nimbus-docs/**"
       - "scripts/templates-check.mjs"
+      - "scripts/fixtures/content-integrity/**"
       - ".github/workflows/templates.yml"
   pull_request:
     branches: [main]
@@ -19,6 +20,7 @@ on:
       - "packages/create-nimbus-docs/**"
       - "packages/nimbus-docs/**"
       - "scripts/templates-check.mjs"
+      - "scripts/fixtures/content-integrity/**"
       - ".github/workflows/templates.yml"
 
 permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,13 @@ Before you open a PR:
 - For every intentional public API break, apply the `breaking-change` PR label and add a linked entry to the comprehensive upgrade manifest. Every entry carries manual guidance; add a migration ID, detector, transform, bounded task, and focused fixtures only when maintainers deliberately classify the change as common, mechanical, and canonically detectable. Run `pnpm upgrades:check`. CI verifies the declaration, pending changeset, and manifest continuity.
 - Check that `pnpm typecheck`, `pnpm -r test`, and `pnpm templates:check` pass.
 
+For Markdown pipeline changes, extend the small mixed-format fixture in
+`scripts/fixtures/content-integrity/`. The template check installs the packed
+framework into a starter and verifies rendered content across clean and warm
+builds. Use bounded combinations in unit tests to check preservation of unrelated
+source across formats, nesting, Unicode, and line endings. A parser-only pass or
+one production corpus is not sufficient evidence of consumer compatibility.
+
 ### Local development
 
 Requires **Node ≥ 22.12.0** and **pnpm 9** (pinned via `packageManager`, so Corepack fetches it for you).

--- a/packages/nimbus-docs/src/_internal/agent-endpoint-assets.ts
+++ b/packages/nimbus-docs/src/_internal/agent-endpoint-assets.ts
@@ -998,23 +998,25 @@ async function preparedHeadingRecord(
   partialResolver: GeneratedMarkdownPartialResolver | undefined,
 ): Promise<PreparedHeadingRecord | null> {
   if (typeof entry.body !== "string" || !entry.headings) return null;
-  const headings = await mergePartialHeadings(
-    entry.body,
-    entry.headings,
-    async (collection, id) =>
-      collection === "partials" ? partials?.entries.get(id) : undefined,
-    async (partial) => {
-      const prepared = partial as PreparedMarkdownEntry;
-      if (!prepared.headings) throw new Error("missing prepared headings");
-      return { headings: prepared.headings };
-    },
-    partialResolver
-      ? {
-          resolvePartialId: ({ file, product }) =>
-            file ? partialResolver.resolve({ file, product }) : undefined,
-        }
-      : undefined,
-  );
+  const headings = /\.md$/iu.test(entry.filePath ?? "")
+    ? entry.headings
+    : await mergePartialHeadings(
+        entry.body,
+        entry.headings,
+        async (collection, id) =>
+          collection === "partials" ? partials?.entries.get(id) : undefined,
+        async (partial) => {
+          const prepared = partial as PreparedMarkdownEntry;
+          if (!prepared.headings) throw new Error("missing prepared headings");
+          return { headings: prepared.headings };
+        },
+        partialResolver
+          ? {
+              resolvePartialId: ({ file, product }) =>
+                file ? partialResolver.resolve({ file, product }) : undefined,
+            }
+          : undefined,
+      );
   return {
     collection: entry.collection,
     id: entry.id,
@@ -1284,12 +1286,12 @@ export async function bakeAgentEndpointAssets(
       );
     }
     const expanded = await expandPreparedPartials(entry.body, {
-      sourceId: `${entry.collection}:${entry.id}`,
+      sourceId: `${entry.collection}:${entry.filePath ?? entry.id}`,
       getPartial,
       resolvePartialId: options.partialResolver?.resolve,
     });
     const markdown = renderEntryAsMarkdown(
-      { body: expanded },
+      { body: expanded, filePath: entry.filePath },
       {
         citationIndex: basedCitationIndex,
         componentMap: renderers,
@@ -1300,31 +1302,33 @@ export async function bakeAgentEndpointAssets(
     llmsRoutePages.push(page);
     if (isDiscoverable(entry)) preparedLlmsPages.push(page);
     if (entry.headings) {
-      const headings = await mergePartialHeadings(
-        entry.body,
-        entry.headings,
-        async (collection, id) =>
-          collection === "partials" ? getPartial(id) : undefined,
-        async (partial) => {
-          const prepared = partial as PreparedMarkdownEntry;
-          if (!prepared.headings) {
-            throw new Error(
-              `nimbus-docs: prepared partial "${prepared.id}" is missing headings.`,
-            );
-          }
-          return {
-            headings: prepared.headings,
-          };
-        },
-        options.partialResolver
-          ? {
-              resolvePartialId: ({ file, product }) =>
-                file
-                  ? options.partialResolver!.resolve({ file, product })
-                  : undefined,
-            }
-          : undefined,
-      );
+      const headings = /\.md$/iu.test(entry.filePath ?? "")
+        ? entry.headings
+        : await mergePartialHeadings(
+            entry.body,
+            entry.headings,
+            async (collection, id) =>
+              collection === "partials" ? getPartial(id) : undefined,
+            async (partial) => {
+              const prepared = partial as PreparedMarkdownEntry;
+              if (!prepared.headings) {
+                throw new Error(
+                  `nimbus-docs: prepared partial "${prepared.id}" is missing headings.`,
+                );
+              }
+              return {
+                headings: prepared.headings,
+              };
+            },
+            options.partialResolver
+              ? {
+                  resolvePartialId: ({ file, product }) =>
+                    file
+                      ? options.partialResolver!.resolve({ file, product })
+                      : undefined,
+                }
+              : undefined,
+          );
       headingRecords.push({
         collection: entry.collection,
         id: entry.id,

--- a/packages/nimbus-docs/src/_internal/authored-links.ts
+++ b/packages/nimbus-docs/src/_internal/authored-links.ts
@@ -5,23 +5,13 @@ import ts from "typescript";
 interface MdNode {
   type?: string;
   name?: unknown;
+  value?: unknown;
   url?: unknown;
   children?: unknown;
   attributes?: unknown;
   position?: {
     start?: { offset?: number };
     end?: { offset?: number };
-  };
-}
-
-interface HtmlNode {
-  type?: string;
-  tagName?: unknown;
-  properties?: unknown;
-  children?: unknown;
-  content?: unknown;
-  position?: {
-    start?: { offset?: number };
   };
 }
 
@@ -58,8 +48,13 @@ function fail(
   offset = 0,
 ): never {
   const before = source.slice(0, offset);
-  const line = before.split("\n").length;
-  const column = offset - before.lastIndexOf("\n");
+  const breaks = [...before.matchAll(/\r\n|\r|\n/gu)];
+  const lastBreak = breaks.at(-1);
+  const line = breaks.length + 1;
+  const column =
+    offset -
+    (lastBreak ? lastBreak.index + lastBreak[0].length : 0) +
+    1;
   throw new Error(
     `Nimbus authored-link normalization failed in ${sourceId ?? "Markdown source"}:${line}:${column}: ${message}`,
   );
@@ -248,117 +243,6 @@ function visit(node: MdNode, callback: (node: MdNode) => void): void {
   }
 }
 
-function visitHtml(node: HtmlNode, callback: (node: HtmlNode) => void): void {
-  callback(node);
-  for (const descendants of [node.children, (node.content as HtmlNode | undefined)?.children]) {
-    if (!Array.isArray(descendants)) continue;
-    for (const child of descendants) {
-      if (child && typeof child === "object") visitHtml(child as HtmlNode, callback);
-    }
-  }
-}
-
-function htmlAttributeValueOffset(
-  raw: string,
-  tagStart: number,
-  attributeName: string,
-): number | null {
-  const isWhitespace = (value: string | undefined) =>
-    value !== undefined && /[\t\n\f\r ]/u.test(value);
-  let index = tagStart;
-  if (raw[index] !== "<") return null;
-  index += 1;
-  while (index < raw.length && !isWhitespace(raw[index]) && !/[/>]/u.test(raw[index]!)) {
-    index += 1;
-  }
-
-  while (index < raw.length) {
-    while (isWhitespace(raw[index])) index += 1;
-    if (raw[index] === ">" || (raw[index] === "/" && raw[index + 1] === ">")) {
-      return null;
-    }
-
-    const nameStart = index;
-    while (
-      index < raw.length &&
-      !isWhitespace(raw[index]) &&
-      !/[=/>]/u.test(raw[index]!)
-    ) {
-      index += 1;
-    }
-    if (index === nameStart) return null;
-    const name = raw.slice(nameStart, index).toLowerCase();
-    while (isWhitespace(raw[index])) index += 1;
-    if (raw[index] !== "=") continue;
-    index += 1;
-    while (isWhitespace(raw[index])) index += 1;
-
-    const quote = raw[index] === '"' || raw[index] === "'" ? raw[index] : null;
-    if (quote) index += 1;
-    const valueStart = index;
-    if (quote) {
-      while (index < raw.length && raw[index] !== quote) index += 1;
-      if (index >= raw.length) return null;
-      index += 1;
-    } else {
-      while (
-        index < raw.length &&
-        !isWhitespace(raw[index]) &&
-        raw[index] !== ">"
-      ) {
-        index += 1;
-      }
-    }
-    if (name === attributeName) return valueStart;
-  }
-  return null;
-}
-
-function staticHtmlHrefOffsets(
-  raw: string,
-  source: string,
-  sourceId: string | undefined,
-  sourceStart: number,
-): number[] {
-  let tree: HtmlNode;
-  try {
-    tree = fromHtml(raw, { fragment: true }) as HtmlNode;
-  } catch (error) {
-    const detail = error instanceof Error ? error.message : String(error);
-    fail(`could not parse HTML: ${detail}`, source, sourceId, sourceStart);
-  }
-  const offsets: number[] = [];
-  visitHtml(tree, (node) => {
-    if (
-      node.type !== "element" ||
-      (node.tagName !== "a" && node.tagName !== "area")
-    ) {
-      return;
-    }
-    const properties = node.properties;
-    if (!properties || typeof properties !== "object") return;
-    const href = (properties as Record<string, unknown>).href;
-    if (typeof href !== "string") return;
-    const tagStart = node.position?.start?.offset;
-    if (typeof tagStart !== "number") {
-      fail("missing HTML anchor source position", source, sourceId, sourceStart);
-    }
-    const localOffset = htmlAttributeValueOffset(raw, tagStart, "href");
-    if (localOffset === null) {
-      fail("could not locate HTML href", source, sourceId, sourceStart + tagStart);
-    }
-    const offset = sourceStart + localOffset;
-    const insertionOffset = rootRelativeInsertionOffset(
-      href,
-      source,
-      sourceId,
-      offset,
-    );
-    if (insertionOffset !== null) offsets.push(insertionOffset);
-  });
-  return offsets;
-}
-
 function isHref(node: MdNode, name: string): boolean {
   return (
     name === "href" || (node.name === "a" && name.toLowerCase() === "href")
@@ -411,78 +295,54 @@ function expressionLiteral(
   return evaluate(expression);
 }
 
-type ParsedJsxNode = ts.JsxElement | ts.JsxSelfClosingElement | ts.JsxFragment;
-
-interface ParsedJsxRange {
-  node: ParsedJsxNode;
-  sourceFile: ts.SourceFile;
-  sourceBase: number;
-}
-
-function jsxRangeKey(start: number, end: number): string {
-  return `${start}:${end}`;
-}
-
 function staticHrefOffsets(
   raw: string,
   node: MdNode,
   source: string,
   sourceId: string | undefined,
   sourceStart: number,
-  parsedRanges: Map<string, ParsedJsxRange>,
 ): number[] {
   if (!Array.isArray(node.attributes)) {
     fail("missing JSX attributes", source, sourceId, sourceStart);
   }
-  if (!node.attributes.some((attribute) =>
-    attribute?.type === "mdxJsxAttribute" &&
-    typeof attribute.name === "string" &&
-    isHref(node, attribute.name)
-  )) return [];
-  const key = jsxRangeKey(sourceStart, sourceStart + raw.length);
-  if (!parsedRanges.has(key)) {
-    const prefix = "const element = (";
-    const parsed = ts.createSourceFile(
-      "nimbus-authored-link.tsx",
-      `${prefix}${raw});`,
-      ts.ScriptTarget.Latest,
-      true,
-      ts.ScriptKind.TSX,
-    );
-    const sourceBase = sourceStart - prefix.length;
-    const matchingStart: ParsedJsxRange[] = [];
-    const collect = (candidate: ts.Node) => {
-      if (
-        ts.isJsxElement(candidate) ||
-        ts.isJsxSelfClosingElement(candidate) ||
-        ts.isJsxFragment(candidate)
-      ) {
-        const range = { node: candidate, sourceFile: parsed, sourceBase };
-        const start = candidate.getStart(parsed) + sourceBase;
-        parsedRanges.set(jsxRangeKey(start, candidate.getEnd() + sourceBase), range);
-        if (start === sourceStart) matchingStart.push(range);
-      }
-      ts.forEachChild(candidate, collect);
-    };
-    collect(parsed);
-    if (!parsedRanges.has(key) && matchingStart.length === 1) {
-      parsedRanges.set(key, matchingStart[0]!);
-    }
-  }
-  const parsedRange = parsedRanges.get(key);
-  if (!parsedRange) {
-    fail("ambiguous JSX range", source, sourceId, sourceStart);
-  }
-  const { node: element, sourceFile: parsed, sourceBase } = parsedRange;
-  if (ts.isJsxFragment(element)) {
-    if (node.attributes.length > 0) {
-      fail("ambiguous JSX fragment", source, sourceId, sourceStart);
-    }
+  // Only the opening tag owns attributes. MDX bodies can contain Markdown and
+  // fenced code that is not valid TSX, so their closing ranges cannot be used
+  // to match TypeScript's JSX nodes to Sätteri's nodes.
+  if (
+    !node.attributes.some((value) => {
+      if (!value || typeof value !== "object") return false;
+      const attribute = value as { name?: unknown };
+      return typeof attribute.name === "string" && isHref(node, attribute.name);
+    })
+  )
     return [];
+  const prefix = "const element = (";
+  const parsed = ts.createSourceFile(
+    "nimbus-authored-link.tsx",
+    `${prefix}${raw});`,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+  const sourceBase = sourceStart - prefix.length;
+  const statement = parsed.statements[0];
+  let expression =
+    statement && ts.isVariableStatement(statement)
+      ? statement.declarationList.declarations[0]?.initializer
+      : undefined;
+  while (expression && ts.isParenthesizedExpression(expression)) {
+    expression = expression.expression;
   }
-  const properties = ts.isJsxElement(element)
-    ? element.openingElement.attributes.properties
-    : element.attributes.properties;
+  const element =
+    expression && ts.isJsxElement(expression)
+      ? expression.openingElement
+      : expression && ts.isJsxSelfClosingElement(expression)
+        ? expression
+        : undefined;
+  if (!element || element.getStart(parsed) + sourceBase !== sourceStart) {
+    fail("ambiguous JSX opening tag", source, sourceId, sourceStart);
+  }
+  const properties = element.attributes.properties;
   if (properties.length !== node.attributes.length) {
     fail("ambiguous JSX attributes", source, sourceId, sourceStart);
   }
@@ -552,11 +412,11 @@ function staticHrefOffsets(
       const insertionOffset =
         isHref(node, attribute.name) && literal
           ? rootRelativeInsertionOffset(
-          literal.value,
-          source,
-          sourceId,
+              literal.value,
+              source,
+              sourceId,
               literal.slashOffset,
-        )
+            )
           : null;
       if (insertionOffset !== null) offsets.push(insertionOffset);
       continue;
@@ -588,19 +448,108 @@ function staticHrefOffsets(
   return offsets;
 }
 
+// HTML owns its attribute ranges and entity decoding; preserve the authored
+// spelling and insert the base only at the parser-identified href value.
+function htmlHrefOffsets(
+  raw: string,
+  html: string,
+  source: string,
+  sourceId: string | undefined,
+  sourceStart: number,
+): number[] {
+  const offsets: number[] = [];
+  let tree: ReturnType<typeof fromHtml>;
+  try {
+    tree = fromHtml(html, { fragment: true, verbose: true });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    fail(`could not parse HTML: ${detail}`, source, sourceId, sourceStart);
+  }
+  // Native Markdown removes container prefixes from HTML node values. Anchor
+  // parser offsets to each original line's matching suffix, preserving quotes,
+  // list indentation and CRLF without re-parsing Markdown container syntax.
+  const rawLines =
+    raw === html ? [] : [...raw.matchAll(/[^\r\n]*(?:\r\n|\r|\n|$)/gu)];
+  const htmlLines = html.split(/\r\n|\r|\n/u);
+  const sourceOffset = (offset: number) => {
+    if (raw === html) return sourceStart + offset;
+    const breaks = [...html.slice(0, offset).matchAll(/\r\n|\r|\n/gu)];
+    const lastBreak = breaks.at(-1);
+    const column =
+      offset - (lastBreak ? lastBreak.index + lastBreak[0].length : 0);
+    const line = htmlLines[breaks.length] ?? "";
+    const nativeIndent = line.length - line.trimStart().length;
+    const original = rawLines[breaks.length];
+    const originalLine = original?.[0].replace(/[\r\n]+$/u, "") ?? "";
+    if (
+      !original ||
+      column < nativeIndent ||
+      !originalLine.endsWith(line.trimStart())
+    ) {
+      fail("ambiguous HTML source line", source, sourceId, sourceStart);
+    }
+    return (
+      sourceStart + original.index + originalLine.length - line.length + column
+    );
+  };
+  const walk = (node: (typeof tree)["children"][number] | typeof tree) => {
+    if (
+      node.type === "element" &&
+      (node.tagName === "a" || node.tagName === "area")
+    ) {
+      const href = node.properties.href;
+      if (typeof href === "string" && couldBeRootRelativeDestination(href)) {
+        const range = node.data?.position?.properties?.href;
+        const start = range?.start.offset;
+        const end = range?.end.offset;
+        if (start === undefined || end === undefined) {
+          fail(
+            "missing HTML href source position",
+            source,
+            sourceId,
+            sourceStart,
+          );
+        }
+        const attribute = html.slice(start, end);
+        const value = /^[^\s=]+\s*=\s*["']?/u.exec(attribute);
+        if (!value)
+          fail(
+            "ambiguous HTML href value",
+            source,
+            sourceId,
+            sourceStart + start,
+          );
+        const offset = sourceOffset(start + value[0].length);
+        const insertionOffset = rootRelativeInsertionOffset(
+          href,
+          source,
+          sourceId,
+          offset,
+        );
+        if (insertionOffset !== null) offsets.push(insertionOffset);
+      }
+    }
+    if (node.type === "element" && node.content) walk(node.content);
+    if ("children" in node) for (const child of node.children) walk(child);
+  };
+  walk(tree);
+  return offsets;
+}
+
 export function normalizeAuthoredLinks(
   source: string,
   options: NormalizeAuthoredLinksOptions,
 ): string {
   const prefix = basePrefix(options.base);
+  const format =
+    options.format ??
+    (/\.md(?:$|[?#])/iu.test(options.sourceId ?? "") ? "markdown" : "mdx");
 
   let tree: MdNode;
   try {
-    const parse = options.format === "markdown" ||
-        (options.format === undefined && options.sourceId?.endsWith(".md"))
-      ? markdownToMdast
-      : mdxToMdast;
-    tree = parse(source) as MdNode;
+    tree = (
+      format === "markdown" ? markdownToMdast(source) : mdxToMdast(source)
+    ) as MdNode;
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
     const location = detail.match(/^(\d+):(\d+):\s*/);
@@ -613,7 +562,6 @@ export function normalizeAuthoredLinks(
   }
   const offsetMap = buildOffsetMap(source);
   const insertions = new Set<number>();
-  const parsedJsxRanges = new Map<string, ParsedJsxRange>();
   let rawTextElement: string | null = null;
   visit(tree, (node) => {
     if (
@@ -628,11 +576,11 @@ export function normalizeAuthoredLinks(
         options.sourceId,
       );
       const insertionOffset = rootRelativeInsertionOffset(
-          node.url,
-          source,
-          options.sourceId,
-          offset,
-        );
+        node.url,
+        source,
+        options.sourceId,
+        offset,
+      );
       if (insertionOffset !== null) {
         insertions.add(insertionOffset);
         return;
@@ -642,24 +590,26 @@ export function normalizeAuthoredLinks(
     if (node.type === "html") {
       const [start, end] = nodeRange(node, offsetMap, source, options.sourceId);
       const raw = source.slice(start, end);
+      const html = typeof node.value === "string" ? node.value : raw;
       if (rawTextElement) {
-        if (raw.toLowerCase().includes(`</${rawTextElement}`)) {
+        if (html.toLowerCase().includes(`</${rawTextElement}`)) {
           rawTextElement = null;
         }
         return;
       }
       const rawTextStart = /^<(script|style|textarea|title|xmp|iframe|noembed|noframes|plaintext)(?:[\t\n\f\r />])/iu.exec(
-        raw,
+        html,
       );
       if (
         rawTextStart &&
-        !raw.toLowerCase().includes(`</${rawTextStart[1]!.toLowerCase()}`)
+        !html.toLowerCase().includes(`</${rawTextStart[1]!.toLowerCase()}`)
       ) {
         rawTextElement = rawTextStart[1]!.toLowerCase();
         return;
       }
-      for (const offset of staticHtmlHrefOffsets(
+      for (const offset of htmlHrefOffsets(
         raw,
+        html,
         source,
         options.sourceId,
         start,
@@ -672,14 +622,21 @@ export function normalizeAuthoredLinks(
     if (node.type !== "mdxJsxFlowElement" && node.type !== "mdxJsxTextElement")
       return;
     const [start, end] = nodeRange(node, offsetMap, source, options.sourceId);
-    const raw = source.slice(start, end);
+    // Sätteri identifies where the body begins. Keep Markdown and fenced
+    // examples out of the TypeScript attribute parser entirely.
+    const firstChild = Array.isArray(node.children)
+      ? (node.children[0] as MdNode | undefined)
+      : undefined;
+    const childOffset = firstChild?.position?.start?.offset;
+    const openingEnd =
+      childOffset === undefined ? end : (offsetMap[childOffset] ?? end);
+    const raw = source.slice(start, openingEnd);
     for (const offset of staticHrefOffsets(
       raw,
       node,
       source,
       options.sourceId,
       start,
-      parsedJsxRanges,
     )) {
       insertions.add(offset);
     }

--- a/packages/nimbus-docs/src/_internal/build-partials.ts
+++ b/packages/nimbus-docs/src/_internal/build-partials.ts
@@ -231,6 +231,8 @@ async function expand(
   options: ExpandPreparedPartialsOptions,
   chain: string[],
 ): Promise<string> {
+  // Plain Markdown has no JSX component invocations or props expressions.
+  if (/\.md$/iu.test(options.sourceId)) return source;
   const prepared = applyParams(source, params, options.sourceId);
   const tree = parseSource(prepared, options.sourceId);
   const offsets = offsetMap(prepared);
@@ -277,7 +279,7 @@ async function expand(
       value: await expand(
         partial.body,
         invocation.params,
-        { ...options, sourceId: `partials:${partial.id}` },
+        { ...options, sourceId: `partials:${partial.filePath ?? partial.id}` },
         [...chain, invocation.file],
       ),
     });

--- a/packages/nimbus-docs/src/_internal/markdown-loader.ts
+++ b/packages/nimbus-docs/src/_internal/markdown-loader.ts
@@ -71,10 +71,21 @@ function proxyStore(
           }
         : entry;
     const overlay = currentEntries();
-    if (!overlay) return Reflect.apply(set, store, [prepared]);
+    if (!overlay) {
+      const current = store.get(prepared.id);
+      if (
+        prepared.digest &&
+        current?.digest === prepared.digest &&
+        current.filePath !== prepared.filePath
+      ) {
+        Reflect.apply(deleteEntry, store, [prepared.id]);
+      }
+      return Reflect.apply(set, store, [prepared]);
+    }
     if (
       prepared.digest &&
-      overlay.get(prepared.id)?.digest === prepared.digest
+      overlay.get(prepared.id)?.digest === prepared.digest &&
+      overlay.get(prepared.id)?.filePath === prepared.filePath
     ) {
       return false;
     }
@@ -325,7 +336,7 @@ export function prepareMarkdownLoader<T extends Loader>(
       );
       const reusable =
         context.meta.get(NIMBUS_MARKDOWN_META_KEY) ===
-        JSON.stringify({ version: 2, ...currentCapability });
+        JSON.stringify({ version: 3, ...currentCapability });
       const epoch = beginPreparedMarkdownLoad(
         root,
         context.collection,
@@ -383,7 +394,7 @@ export function prepareMarkdownLoader<T extends Loader>(
           );
           context.meta.set(
             NIMBUS_MARKDOWN_META_KEY,
-            JSON.stringify({ version: 2, ...sealed }),
+            JSON.stringify({ version: 3, ...sealed }),
           );
         }
         return committed;

--- a/packages/nimbus-docs/src/_internal/prepared-markdown-registry.ts
+++ b/packages/nimbus-docs/src/_internal/prepared-markdown-registry.ts
@@ -103,7 +103,7 @@ function copyEntry(
 
 export function preparedMarkdownCollectionCapability(
   collection: string,
-  entries: Iterable<Pick<PreparedMarkdownEntry, "id" | "body">>,
+  entries: Iterable<Pick<PreparedMarkdownEntry, "id" | "body" | "filePath">>,
   capability: NimbusMarkdownCapability,
 ): PreparedMarkdownCollectionCapability {
   const identities = [...entries]
@@ -112,6 +112,7 @@ export function preparedMarkdownCollectionCapability(
       typeof entry.body === "string"
         ? createHash("sha256").update(entry.body).digest("hex")
         : null,
+      /\.md$/iu.test(entry.filePath ?? "") ? "markdown" : "mdx",
     ])
     .sort(([a], [b]) =>
       String(a) < String(b) ? -1 : String(a) > String(b) ? 1 : 0,
@@ -119,7 +120,7 @@ export function preparedMarkdownCollectionCapability(
   const digest = createHash("sha256")
     .update(
       JSON.stringify({
-        version: 1,
+        version: 2,
         generation: capability.generation,
         base: capability.base,
         collection,

--- a/packages/nimbus-docs/src/_internal/transform.ts
+++ b/packages/nimbus-docs/src/_internal/transform.ts
@@ -44,6 +44,7 @@ export interface RenderEntryAsMarkdownOptions {
 
 interface MarkdownEntry {
   body?: string;
+  filePath?: string;
 }
 
 function protectCode(markdown: string): {
@@ -284,7 +285,8 @@ export function renderEntryAsMarkdown(
   const stripFrontmatter = options.stripFrontmatter ?? true;
   let markdown = entry.body ?? "";
 
-  if (/<Render(?=[\s/>])/.test(protectCode(markdown).markdown)) {
+  const isMdx = !entry.filePath?.endsWith(".md");
+  if (isMdx && /<Render(?=[\s/>])/.test(protectCode(markdown).markdown)) {
     throw new Error(
       "nimbus-docs: renderEntryAsMarkdown no longer expands <Render> partials at runtime. " +
         "Serve it with getMarkdownPayload from @cloudflare/nimbus-docs/agent-endpoints.",
@@ -308,6 +310,8 @@ export function renderEntryAsMarkdown(
       citationIndex: options.citationIndex,
     }).code;
   }
+
+  if (!isMdx) return markdown.trim();
 
   const protectedCode = protectCode(markdown);
   markdown = protectedCode.markdown;

--- a/packages/nimbus-docs/test/agent-endpoint-assets.test.ts
+++ b/packages/nimbus-docs/test/agent-endpoint-assets.test.ts
@@ -70,6 +70,7 @@ function commit(
   entries: Array<{
     id: string;
     body?: string;
+    filePath?: string;
     data?: Record<string, unknown>;
     headings?: Array<{ depth: number; text: string; slug: string }>;
   }>,
@@ -85,6 +86,7 @@ function commit(
       entries.map((entry) => ({
         id: entry.id,
         body: entry.body,
+        filePath: entry.filePath,
         data: { ...entry.data },
       })) as never,
       new Map(entries.map((entry) => [entry.id, entry.headings ?? []])),
@@ -169,6 +171,36 @@ test("bakes compact headings with a revisioned partial resolver", async () => {
     ).body,
     /## Product heading/,
   );
+});
+
+test("does not expand literal Render elements in Markdown headings", async () => {
+  const projectRoot = await root();
+  commit(projectRoot, "docs", [
+    {
+      id: "guide",
+      filePath: "src/content/docs/guide.md",
+      body: '# Guide\n\n<Render file="snippet" />',
+      headings: [{ depth: 1, text: "Guide", slug: "guide" }],
+    },
+  ]);
+  commit(projectRoot, "partials", [
+    {
+      id: "snippet",
+      body: "## Partial heading",
+      headings: [
+        { depth: 2, text: "Partial heading", slug: "partial-heading" },
+      ],
+    },
+  ]);
+
+  const records = await bakePreparedHeadings({
+    root: projectRoot,
+    base: "/docs",
+    indexedCollections: ["docs"],
+  });
+  assert.deepEqual(records[0]?.headings, [
+    { depth: 1, text: "Guide", slug: "guide" },
+  ]);
 });
 
 test("bakes expanded source and transformed Markdown endpoint assets deterministically", async () => {

--- a/packages/nimbus-docs/test/authored-links.test.ts
+++ b/packages/nimbus-docs/test/authored-links.test.ts
@@ -335,3 +335,149 @@ test("rejects an invalid deployment base", () => {
     );
   }
 });
+
+test("normalizes opening-tag links around MDX bodies that are not TSX", () => {
+  const source = [
+    '<Card href="/card">',
+    "",
+    "```ts",
+    "const example = <Unclosed>;",
+    '<a href="/literal">example</a>',
+    "```",
+    "",
+    "[Guide](/guide)",
+    "",
+    '<Card href={"/nested"}>',
+    "",
+    "```ts",
+    "export default { fetch() {} } satisfies Handler<Env>;",
+    "```",
+    "",
+    "</Card>",
+    "",
+    "</Card>",
+  ].join("\n");
+  assert.equal(
+    normalizeAuthoredLinks(source, { base: "/docs" }),
+    source
+      .replace('href="/card"', 'href="/docs/card"')
+      .replace("[Guide](/guide)", "[Guide](/docs/guide)")
+      .replace('href={"/nested"}', 'href={"/docs/nested"}'),
+  );
+  assert.equal(normalizeAuthoredLinks(source, { base: "/" }), source);
+});
+
+test("traverses attribute-free wrappers containing fenced code and nested links", () => {
+  const source = [
+    "1. Configure the prefix.",
+    "",
+    '   <Tabs> <TabItem label="IRR record">',
+    "",
+    "   ```txt",
+    "   cf-validation: <OWNERSHIP_VALIDATION_TOKEN>",
+    "   ```",
+    "",
+    '   <a href="/guide">Guide</a>',
+    "",
+    "   </TabItem> </Tabs>",
+    "",
+    "<TypeScriptExample>",
+    "",
+    "```ts",
+    "export default { fetch() {} } satisfies ExportedHandler<Env>;",
+    "```",
+    "",
+    "</TypeScriptExample>",
+  ].join("\n");
+  assert.equal(normalizeAuthoredLinks(source, { base: "/" }), source);
+  assert.equal(
+    normalizeAuthoredLinks(source, { base: "/docs" }),
+    source.replace('href="/guide"', 'href="/docs/guide"'),
+  );
+});
+
+test("normalization preserves unrelated source across format, nesting, Unicode and line endings", () => {
+  for (const format of ["md", "mdx"] as const) {
+    for (const newline of ["\n", "\r\n"]) {
+      for (const prefix of ["", "😀 文档\n\n"]) {
+        for (const wrapper of format === "md"
+          ? ["plain", "quote", "list"]
+          : ["plain", "quote", "list", "component"]) {
+          const link =
+            format === "md"
+              ? '<a\nHREF = "&sol;html">HTML</a>'
+              : '<Card href={"/html"}>HTML</Card>';
+          const body = [
+            format === "md"
+              ? "<!-- generated {comment} -->"
+              : "{/* comment */}",
+            "",
+            "[Guide](/guide?x=1#top)",
+            "",
+            link,
+            "",
+            "<code>www.example.org</code>",
+            "",
+            '<template>\n<a href="/template">Template</a>\n</template>',
+            "",
+            "```tsx",
+            '<a href="/literal">example</a>',
+            "const value = <Unclosed>;",
+            "```",
+            "",
+            "`[Inline](/literal)`",
+          ].join("\n");
+          const wrap = (text: string) =>
+            wrapper === "quote"
+              ? text
+                  .split("\n")
+                  .map((line) => `> ${line}`)
+                  .join("\n")
+              : wrapper === "list"
+                ? `1. Item\n\n${text
+                    .split("\n")
+                    .map((line) => `   ${line}`)
+                    .join("\n")}`
+                : wrapper === "component" && format === "mdx"
+                  ? `<Card href="/outer">\n\n${text}\n\n</Card>`
+                  : text;
+          const source = (prefix + wrap(body)).replaceAll("\n", newline);
+          const expected = source
+            .replace("[Guide](/guide?x=1#top)", "[Guide](/docs/guide?x=1#top)")
+            .replace('HREF = "&sol;html"', 'HREF = "/docs&sol;html"')
+            .replace('href={"/html"}', 'href={"/docs/html"}')
+            .replace('href="/outer"', 'href="/docs/outer"')
+            .replace('href="/template"', 'href="/docs/template"');
+          const sourceId = `docs:fixture.${format}`;
+          const label = JSON.stringify({ format, newline, prefix, wrapper });
+          assert.equal(
+            normalizeAuthoredLinks(source, { base: "/", sourceId }),
+            source,
+            label,
+          );
+          assert.equal(
+            normalizeAuthoredLinks(source, { base: "/docs", sourceId }),
+            expected,
+            label,
+          );
+        }
+      }
+    }
+  }
+  for (const href of [
+    '"/../escape"',
+    '"&sol;../escape"',
+    "'/safe/%2fescape'",
+  ]) {
+    for (const source of [
+      `<a href=${href}>Link</a>`,
+      `> <a\n> href=${href}>Link</a>`,
+    ]) {
+      assert.throws(
+        () =>
+          normalizeAuthoredLinks(source, { base: "/", format: "markdown" }),
+        /destination escapes its canonical path/,
+      );
+    }
+  }
+});

--- a/packages/nimbus-docs/test/markdown-loader.test.ts
+++ b/packages/nimbus-docs/test/markdown-loader.test.ts
@@ -258,7 +258,7 @@ describe("Markdown loader preparation", () => {
     const metadata = JSON.parse(
       harness.metadata.get(NIMBUS_MARKDOWN_META_KEY)!,
     );
-    assert.equal(metadata.version, 2);
+    assert.equal(metadata.version, 3);
     assert.equal(metadata.generation, 1);
     assert.equal(metadata.base, "/docs");
     assert.match(metadata.digest, /^sha256:[a-f0-9]{64}$/u);
@@ -347,6 +347,47 @@ describe("Markdown loader preparation", () => {
     const prepared = getPreparedMarkdownSnapshot(root)?.collections.get("docs");
     assert.deepEqual(prepared?.entries.get("entry")?.data, {});
     assert.match(prepared?.capability.digest ?? "", /^sha256:[a-f0-9]{64}$/u);
+  });
+
+  test("invalidates warm preparation when a source changes format", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "nimbus-loader-format-"));
+    temporaryRoots.push(root);
+    let filePath = "src/content/docs/guide.mdx";
+    const loader = {
+      name: "format-loader",
+      load(context: LoaderContext) {
+        context.store.set({
+          id: "guide",
+          body: "body",
+          data: {},
+          digest: "fixed",
+          filePath,
+        });
+      },
+    };
+    const wrapped = prepareMarkdownLoader(loader, {
+      generation: 1,
+      base: "/docs",
+      transform: (source, sourceId) =>
+        `${path.extname(sourceId ?? "")}:${source}`,
+    });
+    const harness = createHarness(root);
+
+    await wrapped.load(harness.context);
+    const before = JSON.parse(
+      harness.metadata.get(NIMBUS_MARKDOWN_META_KEY)!,
+    ).digest;
+    assert.equal(harness.entries.get("guide")?.body, ".mdx:body");
+
+    filePath = "src/content/docs/guide.md";
+    await wrapped.load(harness.context);
+    const entry = harness.entries.get("guide");
+    assert.equal(entry?.body, ".md:body");
+    assert.equal(entry?.filePath, "src/content/docs/guide.md");
+    assert.notEqual(
+      JSON.parse(harness.metadata.get(NIMBUS_MARKDOWN_META_KEY)!).digest,
+      before,
+    );
   });
 
   test("commits authoritative digest no-ops and isolated registry snapshots", async () => {

--- a/scripts/fixtures/content-integrity/composed.mdx
+++ b/scripts/fixtures/content-integrity/composed.mdx
@@ -1,0 +1,16 @@
+---
+title: Integrity MDX
+---
+
+<Aside title="Wrapper">
+
+😀 [Markdown guide](/integrity/plain/)
+
+```tsx
+const example = <Unclosed>;
+<a href="/untouched">{notAnExpression}</a>
+```
+
+</Aside>
+
+<Render file="example" />

--- a/scripts/fixtures/content-integrity/plain.md
+++ b/scripts/fixtures/content-integrity/plain.md
@@ -1,0 +1,13 @@
+---
+title: Integrity Markdown
+---
+
+<!-- Generated Markdown can contain HTML comments and literal {braces}. -->
+
+😀 [MDX guide](/integrity/composed/)
+
+<a href="/integrity/composed/">HTML link</a>
+
+```mdx
+<a href="/untouched">{notAnExpression}</a>
+```

--- a/scripts/templates-check.mjs
+++ b/scripts/templates-check.mjs
@@ -11,6 +11,8 @@
  */
 
 import { spawn, spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import assert from "node:assert/strict";
 import {
   existsSync,
   mkdtempSync,
@@ -250,6 +252,13 @@ const scaffoldArgs = [
 if (LANE !== "static") scaffoldArgs.push("--adapter", LANE);
 run("node", scaffoldArgs, { cwd: work });
 const site = join(work, "ci-site");
+// Keep a small mixed-format consumer fixture in the existing packed-package
+// gate: unit-level compilation does not exercise content sync or starter renderers.
+const integrityDir = join(site, "src", "content", "docs", "integrity");
+mkdirSync(integrityDir, { recursive: true });
+for (const name of ["plain.md", "composed.mdx"]) {
+  writeFileSync(join(integrityDir, name), readFileSync(join(ROOT, "scripts", "fixtures", "content-integrity", name)));
+}
 mkdirSync(join(site, "src", "pages", "api"), { recursive: true });
 writeFileSync(
   join(site, "src", "pages", "custom-static.astro"),
@@ -381,6 +390,44 @@ writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
 run(SCAFFOLD_PM_BIN, [...SCAFFOLD_PM_PREFIX, "install", "--no-frozen-lockfile"], { cwd: site });
 run(SCAFFOLD_PM_BIN, [...SCAFFOLD_PM_PREFIX, "typecheck"], { cwd: site });
 run(SCAFFOLD_PM_BIN, [...SCAFFOLD_PM_PREFIX, "build"], { cwd: site });
+
+if (LANE === "static") {
+  const { JSDOM } = createRequire(join(ROOT, "packages", "nimbus-docs", "package.json"))("jsdom");
+  const readPage = (slug) => new JSDOM(readFileSync(join(site, "dist", "integrity", slug, "index.html"), "utf8")).window.document;
+  const plain = readPage("plain");
+  const composed = readPage("composed");
+  const readGenerated = () =>
+    ["plain", "composed"].flatMap(slug =>
+      ["md", "mdx"].map(extension =>
+        readFileSync(join(site, "dist", "integrity", slug, `index.${extension}`), "utf8"),
+      ),
+    );
+  const generated = readGenerated();
+  assert.deepEqual([...composed.querySelectorAll("aside[role=note]")].map(node => node.getAttribute("aria-label")), ["Wrapper"]);
+  assert.equal([...plain.querySelectorAll("a")].find(node => node.textContent === "HTML link")?.getAttribute("href"), "/integrity/composed/");
+  assert.equal([...plain.querySelectorAll("a")].find(node => node.textContent === "MDX guide")?.getAttribute("href"), "/integrity/composed/");
+  assert.ok(composed.querySelector('a[href="/integrity/plain/"]'));
+  assert.ok(composed.body.textContent.includes("This text lives in"), "partial renders through the starter");
+  for (const document of [plain, composed]) {
+    assert.ok([...document.querySelectorAll("pre")].some(node => node.textContent.includes('<a href="/untouched">{notAnExpression}</a>')), "fenced examples retain their literal content");
+    assert.equal(document.querySelector('a[href="/untouched"]'), null);
+  }
+  assert.ok(generated.some(source => source.includes("<!-- Generated Markdown can contain HTML comments and literal {braces}. -->")));
+  assert.ok(generated.some(source => source.includes('<a href="/untouched">{notAnExpression}</a>')));
+  // Reuse the content cache: prepared links and content must not change on a
+  // second build of the same installed consumer.
+  const snapshot = (document) => ({
+    components: [...document.querySelectorAll("aside[role=note]")].map(node => [node.getAttribute("aria-label"), node.textContent]),
+    code: [...document.querySelectorAll("pre")].map(node => node.textContent),
+    links: [...document.querySelectorAll('a[href^="/integrity/"]')].map(node => node.getAttribute("href")),
+  });
+  const before = [snapshot(plain), snapshot(composed)];
+  const generatedBefore = generated;
+  run(SCAFFOLD_PM_BIN, [...SCAFFOLD_PM_PREFIX, "build"], { cwd: site });
+  assert.deepEqual([snapshot(readPage("plain")), snapshot(readPage("composed"))], before);
+  assert.deepEqual(readGenerated(), generatedBefore);
+  ok("mixed Markdown/MDX content, partials, literal examples and warm builds preserve their output");
+}
 
 const staticRouteCandidates = [
   join(site, "dist", "custom-static", "index.html"),


### PR DESCRIPTION
## Summary
- preserve authored Markdown and MDX bytes while normalizing links
- retain source positions through prepared Markdown, partials, and agent endpoint generation
- add content-integrity template acceptance coverage

## Validation
- `pnpm --filter nimbus-docs test`
- `pnpm --filter nimbus-docs typecheck`
- `pnpm lint`
- `pnpm templates:check`
- clean final review

Split from and intended to replace the authored-content portion of #131.