### PR TITLE
fix: prevent streamed API code-rail layout shift

### DIFF
--- a/.changeset/stable-api-code-rail.md
+++ b/.changeset/stable-api-code-rail.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/create-nimbus-docs": patch
+---
+
+Reserve the desktop API code-rail column before streamed rail HTML arrives, preventing the main content from shifting sideways. Preserve mobile stacking, no-rail layouts, and custom rail width. Existing sites can copy the updated owned ApiLayout component if desired; updating the framework does not overwrite it. This prevents layout shift without making the rail arrive sooner.

--- a/packages/nimbus-starter-source/src/components/ui/api-layout/ApiLayout.astro
+++ b/packages/nimbus-starter-source/src/components/ui/api-layout/ApiLayout.astro
@@ -11,6 +11,7 @@ import { ApiSidebar } from "@/components/ui/api-sidebar";
 import { ApiCodeRail } from "@/components/ui/api-code-rail";
 import { Banner } from "@/components/ui/banner";
 import ApiBody from "./ApiBody.astro";
+import { cn } from "@/lib/cn";
 import { getApiVersionAlternates, getVersionStatus, withBase } from "@cloudflare/nimbus-docs/runtime";
 import type { ApiNav, ApiPageProps } from "@cloudflare/nimbus-docs/api";
 
@@ -66,7 +67,13 @@ if (versionStatus?.isHidden) {
     <div class="pointer-events-none sticky bottom-0 h-8 bg-gradient-to-t from-background to-transparent"></div>
   </aside>
 
-  <div data-api-layout class="flex min-w-0 flex-1 flex-col min-[90rem]:flex-row">
+  {/* Reserve both desktop tracks before the streamed body/rail HTML arrives.
+      Flex only reserves the rail's width once its later sibling is parsed,
+      making long API bodies reflow sideways during navigation. */}
+  <div data-api-layout class={cn(
+    "flex min-w-0 flex-1 flex-col",
+    hasRail && "min-[90rem]:grid min-[90rem]:grid-cols-[minmax(0,1fr)_29rem] 2xl:grid-cols-[minmax(0,1fr)_var(--nb-code-rail-width)]",
+  )}>
     <main id="main-content" tabindex="-1" class="min-w-0 flex-1" {...pagefindAttrs}>
       <div class="mx-auto max-w-(--nb-content-max) px-4 md:px-8 2xl:px-16 pt-8 pb-12">
         {pagefindDeprecated && <span hidden data-pagefind-filter="status:deprecated"></span>}


### PR DESCRIPTION
## What & why

Prevent the main API body from shifting sideways when Astro streams the code rail after the body. The previous desktop flex layout only allocated the rail's width once its HTML arrived.

Use a conditional CSS grid on the existing layout container to reserve the rail track immediately. Preserve the existing content gate, 90rem/2xl widths, custom `--nb-code-rail-width`, sticky positioning, mobile stacking, and full-width pages without a rail.

This is the maintainer-approved code-rail layout ticket from the API SSR work breakdown. It is independent of the prepared-data/live-entry experiments: no framework, API contract, pagination, adapter, or runtime changes. The PR contains only the canonical owned layout and its scaffolder patch changeset.

Existing sites can copy the updated owned `ApiLayout.astro` if desired; a framework upgrade does not overwrite their components. This prevents layout shift, not delayed rail delivery itself.

## Verification

Disposable Chrome streaming check using the actual compiled API components and CSS:

- Flush the head and main body, withhold the entire rail wrapper, assert the rail is absent, then explicitly release it and compare main-content geometry. JavaScript is disabled for these measurements.
- **25 fixed cases, maximum shift 0 CSS px**: sample rail, response-only rail, no-rail operation, and API overview at 390/1439/1440/1535/1536/1600px, plus a custom 30rem rail.
- **Old flex-row negative control: 544 CSS px shift** at 1600px.
- Sticky position/width, mobile stacking, and full-width no-rail pages pass.
- JavaScript-enabled language picker, response tabs, keyboard disclosures, skip-link focus, field anchors, and main-before-rail DOM order pass.
- No permanent browser harness or customer dependency added. The verified layout/body/rail/style source is unchanged by moving this atomic fix onto current `main`.

Contributor-guide checks rerun successfully on current `main` plus this commit:

- `pnpm typecheck` — passes, zero errors/warnings (six existing docs-app hints).
- `pnpm --filter nimbus-starter-source build` — passes.
- `pnpm templates:check` — passes (generator, packed framework, consumer scaffold/typecheck/build).
- `pnpm -r test` — 1,658 passed, 0 failed, 1 skipped, with the terminal environment described below.

The test command unsets `AI_AGENT`, `CODEX_SANDBOX`, `CODEX_CI`, and `CODEX_THREAD_ID` so human-terminal CLI tests do not inherit this coding session's agent-handoff mode. Tests specifically covering agent mode still set their own environment. No tests or product code were changed to obtain a pass.

## Checklist

- [x] A maintainer approved this work, or I'm on the team (same-repository maintainer PR)
- [x] Correct tier: owned starter layout
- [x] Edited `packages/nimbus-starter-source/`, not the generated `templates` branch
- [x] `create-nimbus-docs` patch changeset added
- [x] No public API break; `breaking-change` label and upgrade manifest entry are not applicable
- [x] `pnpm typecheck`, `pnpm -r test`, and `pnpm templates:check` all green
