### PR TITLE
perf: reduce repeated API field-icon markup

### DIFF
--- a/.changeset/compact-api-field-icons.md
+++ b/.changeset/compact-api-field-icons.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/create-nimbus-docs": patch
+---
+
+Reduce repeated API field-icon markup by sharing SVG paint settings in the existing field-list stylesheet. Preserve icon shapes, field content, links, and disclosure behavior. Existing sites can apply the owned component and stylesheet changes together; framework upgrades do not overwrite owned files.

--- a/packages/nimbus-starter-source/src/components/ui/api-field-row/ApiFieldRow.astro
+++ b/packages/nimbus-starter-source/src/components/ui/api-field-row/ApiFieldRow.astro
@@ -22,7 +22,7 @@ const constraints = constraintPairs(field.constraints);
 const omitted = field.childCount - field.children.length;
 const detail = (v: unknown): string => JSON.stringify(v);
 
-const linkSvg = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>`;
+const linkSvg = `<svg viewBox="0 0 24 24"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>`;
 ---
 
 <li
@@ -89,7 +89,7 @@ const linkSvg = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stro
       {expandable && (
         <details class="fl-expandable" open={startOpen}>
           <summary class="fl-expand-trigger">
-            <svg class="fl-expand-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m9 18 6-6-6-6"/></svg>
+            <svg class="fl-expand-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="m9 18 6-6-6-6"/></svg>
             {field.union
               ? `${field.union.variants.length} variants`
               : `${field.childCount} properties`}

--- a/packages/nimbus-starter-source/src/components/ui/api-field-row/ApiUnionExplorer.astro
+++ b/packages/nimbus-starter-source/src/components/ui/api-field-row/ApiUnionExplorer.astro
@@ -44,7 +44,7 @@ const entries =
             )}
             <details class="fl-expandable" open={i === 0 && AUTO_OPEN_DEPTH >= depth + 1}>
               <summary class="fl-expand-trigger">
-                <svg class="fl-expand-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m9 18 6-6-6-6"/></svg>
+                <svg class="fl-expand-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="m9 18 6-6-6-6"/></svg>
                 {variant.fields!.length} properties
               </summary>
               <ul class="fl-list fl-children">

--- a/packages/nimbus-starter-source/src/components/ui/api-field-row/field-list.css
+++ b/packages/nimbus-starter-source/src/components/ui/api-field-row/field-list.css
@@ -14,6 +14,18 @@
   --fl-guide: calc(var(--fl-icon) / 2);
 }
 
+/* Repeated field icons share paint here instead of repeating five SVG
+   presentation attributes on every field and union preview in the HTML. */
+@layer base {
+  :where(.fl-anchor svg, .fl-expand-icon) {
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+}
+
 /* ---- Section header ---- */
 .fl-head {
   display: flex;


### PR DESCRIPTION
## What & why

Reduce repeated API field-icon HTML by moving five SVG paint attributes into the existing shared `field-list.css` base layer. Keep the exact link/chevron paths, viewBoxes, dimensions, field content, anchors and disclosure behavior.

This is the maintainer-approved field-icon markup ticket from the API SSR work breakdown. It is an independent four-file change: two owned components, their stylesheet and a scaffolder patch changeset. No framework, code-rail, pagination, API contract or runtime changes.

The zero-specificity selector keeps user CSS overrides working. Each field consumer already imports the shared stylesheet, including standalone row/union use. Existing sites must apply the component and stylesheet changes together; framework upgrades do not overwrite owned files.

## Verification

- `pnpm typecheck`: passed (zero errors/warnings; six existing docs-app hints).
- Canonical starter build, `pnpm build:templates`, and `pnpm templates:check`: passed.
- Full workspace tests: **1,663 passed, 0 failed, 1 skipped**. Human-terminal CLI tests run with `AI_AGENT`, `CODEX_SANDBOX`, `CODEX_CI` and `CODEX_THREAD_ID` unset; explicit agent-mode tests retain their own environment.
- Disposable before/after Astro builds use identical SmallCo data; only the three icon/CSS files differ.
- Chrome: **15 rendered SVGs** have identical paths, viewBoxes, bounding boxes and computed paint in light/dark themes, both with and without a user stroke override. These comparisons run with JavaScript disabled.
- Field text, link targets and anchor IDs match. Mouse/keyboard disclosures and field-link navigation pass on both builds with JavaScript enabled.
- Rendered SVG markup: **3,932 → 2,462 bytes**, saving **1,470 bytes** across 15 icons (98 bytes per occurrence). This is SVG markup only, not a whole-response/compression/latency claim; the small shared CSS rule is additional.
- No permanent browser harness or customer dependency added.

Fixture scope: the disposable dependency overlay could not resolve Astro ClientRouter style metadata, so both test shells omit ClientRouter identically; this does not qualify SPA navigation. The overlay also links the already-installed Satteri native binding. Direct fixture builds logged a Pagefind executable warning, so they do not qualify search. The separate unmodified canonical starter and packed-template builds passed. No product configuration was changed for these fixture workarounds.

## Checklist

- [x] A maintainer approved this work, or I'm on the team (same-repository maintainer PR)
- [x] Correct tier: owned starter components/styles
- [x] Edited `packages/nimbus-starter-source/`, not the generated `templates` branch
- [x] `create-nimbus-docs` patch changeset added
- [x] No public API break; `breaking-change` label and upgrade manifest entry are not applicable
- [x] `pnpm typecheck`, `pnpm -r test`, and `pnpm templates:check` all green
